### PR TITLE
[codex] Harmonize evaluation reporting and dataset utilities

### DIFF
--- a/apps/evalGal3NavStateImuEKFNEES.cpp
+++ b/apps/evalGal3NavStateImuEKFNEES.cpp
@@ -13,103 +13,120 @@
  * @author Alec Kain
  */
 
-#include "EKFNEESEvaluator.h"
-#include <iostream>
 #include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include "AppUtils.h"
+#include "EKFNEESEvaluator.h"
 
 using namespace gtsam;
 using namespace std;
 
-/// NEES results for all intervals
+namespace {
+
+constexpr double kAlpha = 3.0;
+const vector<double> kIntervals{0.2, 0.5, 1.0};
+
+/// NEES results for all intervals.
 struct DatasetResults {
-    NEESResults gal3_0_2s;
-    NEESResults gal3_0_5s;
-    NEESResults gal3_1_0s;
-    NEESResults navstate_0_2s;
-    NEESResults navstate_0_5s;
-    NEESResults navstate_1_0s;
+  NEESResults gal3_0_2s;
+  NEESResults gal3_0_5s;
+  NEESResults gal3_1_0s;
+  NEESResults navstate_0_2s;
+  NEESResults navstate_0_5s;
+  NEESResults navstate_1_0s;
 };
 
-/// Print table header
-static void printTableHeader() {
-    cout << "\n" << string(70, '=') << "\n";
-    cout << "Dataset\t\tMethod\t\t\t0.2s\t0.5s\t1.0s\n";
-    cout << string(70, '-') << "\n";
-}
+struct ResultRow {
+  string datasetName;
+  DatasetResults results;
+};
 
-/// Print NEES results row
-static void printTableRow(const string& datasetName,
-                         const string& methodName,
-                         const NEESResults& result_0_2s,
-                         const NEESResults& result_0_5s,
-                         const NEESResults& result_1_0s) {
-    cout << datasetName << "\t" << methodName << ":\t"
-         << fixed << setprecision(3)
-         << result_0_2s.median << "\t"
-         << result_0_5s.median << "\t"
-         << result_1_0s.median << "\n";
-}
+/// Print usage for the EKF comparison app.
+void printUsage(const char* programName) { printDatasetAppUsage(programName); }
 
-/// Evaluate single dataset
-static DatasetResults evaluateDataset(const string& datasetPath, const string& datasetName) {
-    Dataset dataset(datasetPath);
-    EKFNEESEvaluator evaluator(dataset);
-    
-    DatasetResults results;
-    
-    // Evaluate Gal3ImuEKF - use public API with dataset name
-    results.gal3_0_2s = evaluator.runGal3ImuEKF(0.2, 3, datasetName);
-    results.gal3_0_5s = evaluator.runGal3ImuEKF(0.5, 3, datasetName);
-    results.gal3_1_0s = evaluator.runGal3ImuEKF(1.0, 3, datasetName);
-    
-    // Evaluate NavStateImuEKF - use public API with dataset name
-    results.navstate_0_2s = evaluator.runNavStateImuEKF(0.2, 3, datasetName);
-    results.navstate_0_5s = evaluator.runNavStateImuEKF(0.5, 3, datasetName);
-    results.navstate_1_0s = evaluator.runNavStateImuEKF(1.0, 3.0, datasetName);
-    
-    return results;
-}
-
-/// Main evaluation program
-int main(int argc, char* argv[]) {
-    try {
-        printTableHeader();
-        
-        // Evaluate MH01 dataset
-        const string mh01Path = "../data/euroc/euroc_MH01.csv";
-        DatasetResults mh01Results = evaluateDataset(mh01Path, "MH01");
-        
-        printTableRow("MH01", "Gal3ImuEKF", 
-                     mh01Results.gal3_0_2s, mh01Results.gal3_0_5s, mh01Results.gal3_1_0s);
-        printTableRow("MH01", "NavStateImuEKF", 
-                     mh01Results.navstate_0_2s, mh01Results.navstate_0_5s, mh01Results.navstate_1_0s);
-        
-        cout << string(70, '-') << "\n";
-        
-        // Evaluate V202 dataset
-        const string v202Path = "../data/euroc/euroc_V202.csv";
-        DatasetResults v202Results = evaluateDataset(v202Path, "V202");
-        
-        printTableRow("V202", "Gal3ImuEKF", 
-                     v202Results.gal3_0_2s, v202Results.gal3_0_5s, v202Results.gal3_1_0s);
-        printTableRow("V202", "NavStateImuEKF", 
-                     v202Results.navstate_0_2s, v202Results.navstate_0_5s, v202Results.navstate_1_0s);
-        
-        cout << string(70, '=') << "\n\n";
-        cout << "Final table results for 0.2, 0.5, 1s preintegration times:" << "\n";
-        printTableRow("MH01", "Gal3ImuEKF", 
-                     mh01Results.gal3_0_2s, mh01Results.gal3_0_5s, mh01Results.gal3_1_0s);
-        printTableRow("MH01", "NavStateImuEKF", 
-                     mh01Results.navstate_0_2s, mh01Results.navstate_0_5s, mh01Results.navstate_1_0s);
-        printTableRow("V202", "Gal3ImuEKF", 
-                     v202Results.gal3_0_2s, v202Results.gal3_0_5s, v202Results.gal3_1_0s);
-        printTableRow("V202", "NavStateImuEKF", 
-                     v202Results.navstate_0_2s, v202Results.navstate_0_5s, v202Results.navstate_1_0s);
-        
-        return 0;
-        
-    } catch (const exception& e) {
-        cerr << "Error: " << e.what() << "\n";
-        return 1;
+/// Validate any EKF-specific trailing arguments.
+void parseAppArguments(const vector<string>& arguments,
+                       const char* programName) {
+  for (const string& argument : arguments) {
+    if (isHelpArgument(argument)) {
+      printUsage(programName);
+      std::exit(0);
     }
+    throw runtime_error("Unknown argument: " + argument);
+  }
+}
+
+/// Print table header.
+static void printTableHeader() {
+  cout << "\n" << string(70, '=') << "\n";
+  cout << "Dataset\t\tMethod\t\t\t0.2s\t0.5s\t1.0s\n";
+  cout << string(70, '-') << "\n";
+}
+
+/// Print NEES results row.
+static void printTableRow(const string& datasetName, const string& methodName,
+                          const NEESResults& result_0_2s,
+                          const NEESResults& result_0_5s,
+                          const NEESResults& result_1_0s) {
+  cout << datasetName << "\t" << methodName << ":\t" << fixed << setprecision(3)
+       << result_0_2s.median << "\t" << result_0_5s.median << "\t"
+       << result_1_0s.median << "\n";
+}
+
+/// Accumulate EKF comparison rows for each requested dataset.
+struct RunForDataset {
+  vector<ResultRow> rows;
+
+  void operator()(const string& datasetName, const Dataset& dataset) {
+    EKFNEESEvaluator evaluator(dataset);
+
+    DatasetResults results;
+    results.gal3_0_2s =
+        evaluator.runGal3ImuEKF(kIntervals[0], kAlpha, datasetName);
+    results.gal3_0_5s =
+        evaluator.runGal3ImuEKF(kIntervals[1], kAlpha, datasetName);
+    results.gal3_1_0s =
+        evaluator.runGal3ImuEKF(kIntervals[2], kAlpha, datasetName);
+    results.navstate_0_2s =
+        evaluator.runNavStateImuEKF(kIntervals[0], kAlpha, datasetName);
+    results.navstate_0_5s =
+        evaluator.runNavStateImuEKF(kIntervals[1], kAlpha, datasetName);
+    results.navstate_1_0s =
+        evaluator.runNavStateImuEKF(kIntervals[2], kAlpha, datasetName);
+    rows.push_back({datasetName, results});
+  }
+
+  void print() const {
+    printTableHeader();
+    for (size_t index = 0; index < rows.size(); ++index) {
+      const ResultRow& row = rows[index];
+      printTableRow(row.datasetName, "Gal3ImuEKF", row.results.gal3_0_2s,
+                    row.results.gal3_0_5s, row.results.gal3_1_0s);
+      printTableRow(row.datasetName, "NavStateImuEKF",
+                    row.results.navstate_0_2s, row.results.navstate_0_5s,
+                    row.results.navstate_1_0s);
+      if (index + 1 != rows.size()) {
+        cout << string(70, '-') << "\n";
+      }
+    }
+    cout << string(70, '=') << "\n";
+  }
+};
+
+}  // namespace
+
+/// Main evaluation program.
+int main(int argc, char* argv[]) {
+  const auto datasetCli = resolveDatasetAppCli(argc, argv);
+  parseAppArguments(datasetCli.remainingArgs, argv[0]);
+
+  RunForDataset runner;
+  const int status = runForDatasets(datasetCli, runner);
+  if (status != 0) {
+    return status;
+  }
+  runner.print();
+  return 0;
 }

--- a/apps/evalGal3NavStateImuEKFNEES.cpp
+++ b/apps/evalGal3NavStateImuEKFNEES.cpp
@@ -26,7 +26,6 @@ using namespace std;
 namespace {
 
 constexpr double kAlpha = 3.0;
-const vector<double> kIntervals{0.2, 0.5, 1.0};
 
 /// NEES results for all intervals.
 struct DatasetResults {
@@ -43,12 +42,14 @@ struct ResultRow {
   DatasetResults results;
 };
 
+struct AppOptions {};
+
 /// Print usage for the EKF comparison app.
 void printUsage(const char* programName) { printDatasetAppUsage(programName); }
 
 /// Validate any EKF-specific trailing arguments.
-void parseAppArguments(const vector<string>& arguments,
-                       const char* programName) {
+AppOptions parseAppArguments(const vector<string>& arguments,
+                             const char* programName) {
   for (const string& argument : arguments) {
     if (isHelpArgument(argument)) {
       printUsage(programName);
@@ -56,6 +57,7 @@ void parseAppArguments(const vector<string>& arguments,
     }
     throw runtime_error("Unknown argument: " + argument);
   }
+  return {};
 }
 
 /// Print table header.
@@ -77,6 +79,10 @@ static void printTableRow(const string& datasetName, const string& methodName,
 
 /// Accumulate EKF comparison rows for each requested dataset.
 struct RunForDataset {
+  explicit RunForDataset(const AppOptions&)
+      : intervals(defaultQuadratureIntervals()) {}
+
+  vector<double> intervals;
   vector<ResultRow> rows;
 
   void operator()(const string& datasetName, const Dataset& dataset) {
@@ -84,21 +90,21 @@ struct RunForDataset {
 
     DatasetResults results;
     results.gal3_0_2s =
-        evaluator.runGal3ImuEKF(kIntervals[0], kAlpha, datasetName);
+        evaluator.runGal3ImuEKF(intervals[0], kAlpha, datasetName);
     results.gal3_0_5s =
-        evaluator.runGal3ImuEKF(kIntervals[1], kAlpha, datasetName);
+        evaluator.runGal3ImuEKF(intervals[1], kAlpha, datasetName);
     results.gal3_1_0s =
-        evaluator.runGal3ImuEKF(kIntervals[2], kAlpha, datasetName);
+        evaluator.runGal3ImuEKF(intervals[2], kAlpha, datasetName);
     results.navstate_0_2s =
-        evaluator.runNavStateImuEKF(kIntervals[0], kAlpha, datasetName);
+        evaluator.runNavStateImuEKF(intervals[0], kAlpha, datasetName);
     results.navstate_0_5s =
-        evaluator.runNavStateImuEKF(kIntervals[1], kAlpha, datasetName);
+        evaluator.runNavStateImuEKF(intervals[1], kAlpha, datasetName);
     results.navstate_1_0s =
-        evaluator.runNavStateImuEKF(kIntervals[2], kAlpha, datasetName);
+        evaluator.runNavStateImuEKF(intervals[2], kAlpha, datasetName);
     rows.push_back({datasetName, results});
   }
 
-  void print() const {
+  void report() const {
     printTableHeader();
     for (size_t index = 0; index < rows.size(); ++index) {
       const ResultRow& row = rows[index];
@@ -120,13 +126,14 @@ struct RunForDataset {
 /// Main evaluation program.
 int main(int argc, char* argv[]) {
   const auto datasetCli = resolveDatasetAppCli(argc, argv);
-  parseAppArguments(datasetCli.remainingArgs, argv[0]);
+  const AppOptions appOptions =
+      parseAppArguments(datasetCli.remainingArgs, argv[0]);
 
-  RunForDataset runner;
+  RunForDataset runner(appOptions);
   const int status = runForDatasets(datasetCli, runner);
   if (status != 0) {
     return status;
   }
-  runner.print();
+  runner.report();
   return 0;
 }

--- a/apps/evalQuadratureImuFactorDiagnostics.cpp
+++ b/apps/evalQuadratureImuFactorDiagnostics.cpp
@@ -175,175 +175,197 @@ Summary runStandardNees(const vector<Window>& windows) {
   return samples.summarize();
 }
 
+struct AppOptions {
+  size_t maxIntervals = 0;
+};
+
+void printUsage(const char* programName) {
+  cout << "Usage: " << programName
+       << " [--data-dir <path>] [--dataset <name>] [--max-intervals <count>]\n";
+  cout << "  --data-dir <path>       Dataset directory (default: "
+          "../data/euroc/)\n";
+  cout << "  --dataset <name>        Restrict to one dataset (e.g. MH01 or "
+          "euroc_MH01.csv)\n";
+  cout << "  --max-intervals <count> Restrict to first N default intervals\n";
+}
+
+AppOptions parseAppArguments(const vector<string>& arguments,
+                             const char* programName) {
+  for (const string& argument : arguments) {
+    if (isHelpArgument(argument)) {
+      printUsage(programName);
+      std::exit(0);
+    }
+  }
+  return {parseMaxIntervalsArgument(arguments)};
+}
+
+struct RunForDataset {
+  explicit RunForDataset(vector<double> intervals)
+      : intervals(std::move(intervals)) {}
+
+  vector<double> intervals;
+  vector<Row> rows;
+
+  void operator()(const string& datasetName, const Dataset& dataset) {
+    for (double intervalSeconds : intervals) {
+      const size_t m = dataset.stepsForInterval(intervalSeconds);
+      const size_t N = max<size_t>(
+          3, static_cast<size_t>(floor(sqrt(static_cast<double>(m)))));
+
+      // Compare quadrature against the two standard preintegration variants.
+      Row row;
+      row.dataset = datasetName;
+      row.interval = intervalSeconds;
+      row.samplesPerWindow = m;
+      row.quadratureNodes = N;
+      const auto windows = dataset.completeWindows(m);
+      row.quadrature = runQuadratureNees(windows, N);
+      row.manifold = runStandardNees<PIMManifold>(windows);
+      row.tangent = runStandardNees<PIMTangent>(windows);
+      rows.push_back(row);
+
+      cout << "[done] " << datasetName << " dt=" << fixed << setprecision(1)
+           << intervalSeconds << "s m=" << m << " N=" << N
+           << " NEES_median=" << setprecision(3) << row.quadrature.nees.median
+           << "\n";
+    }
+  }
+};
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  try {
-    // Resolve the datasets and interval subset requested on the command line.
-    const AppCliOptions options = parseDatasetAppCliOptions(argc, argv);
-    const vector<pair<string, string>> discoveredDatasets =
-        discoverFilteredDatasets(options.dataDirectory, DatasetFilters::all);
-    const vector<pair<string, string>> datasets =
-        selectDatasets(discoveredDatasets, options.datasetName);
+  // Resolve the datasets and interval subset requested on the command line.
+  const auto datasetCli = resolveDatasetAppCli(argc, argv);
+  const AppOptions appOptions =
+      parseAppArguments(datasetCli.remainingArgs, argv[0]);
 
-    if (datasets.empty()) {
-      cerr << "No datasets found in " << options.dataDirectory << "\n";
-      return 1;
-    }
+  const vector<double> defaultIntervals = defaultQuadratureIntervals();
+  const vector<double> intervals =
+      selectIntervals(defaultIntervals, appOptions.maxIntervals);
 
-    const vector<double> defaultIntervals = defaultQuadratureIntervals();
-    const vector<double> intervals =
-        selectIntervals(defaultIntervals, options.maxIntervals);
+  // Evaluate all requested datasets and window lengths.
+  RunForDataset runner(intervals);
+  const int status = runForDatasets(datasetCli, runner);
+  if (status != 0) {
+    return status;
+  }
+  const vector<Row>& rows = runner.rows;
 
-    // Evaluate all requested datasets and window lengths.
-    vector<Row> rows;
-    for (const auto& datasetEntry : datasets) {
-      const string& datasetPath = datasetEntry.second;
-      Dataset dataset(datasetPath);
-      if (dataset.truth.size() < 2) continue;
-      const string& datasetName = datasetEntry.first;
+  // Table 1 is the direct normalized-NEES comparison across the three
+  // methods.
+  cout << "\n## Table 1: Normalized NEES Median (full 9-DOF)\n\n";
+  cout << "| dataset | dt(s) | m | N | quad | manifold | tangent |\n";
+  cout << "|---|---:|---:|---:|---:|---:|---:|\n";
+  for (const auto& row : rows) {
+    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+         << row.interval << " | " << row.samplesPerWindow << " | "
+         << row.quadratureNodes << " | " << setprecision(3)
+         << row.quadrature.nees.median << " | " << row.manifold.nees.median
+         << " | " << row.tangent.nees.median << " |\n";
+  }
 
-      for (double intervalSeconds : intervals) {
-        const size_t m = dataset.stepsForInterval(intervalSeconds);
-        const size_t N = max<size_t>(
-            3, static_cast<size_t>(floor(sqrt(static_cast<double>(m)))));
+  // Table 1b exposes how quadrature's observed errors compare to its
+  // covariance scale.
+  cout << "\n## Table 1b: Quad Error vs Predicted Sigma (median)\n\n";
+  cout << "| dataset | dt(s) | m | N | NEES"
+       << " | err_rot | sig_rot | err_pos | sig_pos | err_vel | sig_vel |\n";
+  cout << "|---|---:|---:|---:|---:"
+       << "|---:|---:|---:|---:|---:|---:|\n";
+  for (const auto& row : rows) {
+    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+         << row.interval << " | " << row.samplesPerWindow << " | "
+         << row.quadratureNodes << " | " << setprecision(3)
+         << row.quadrature.nees.median << " | " << setprecision(6)
+         << row.quadrature.rotErrorMedian << " | "
+         << row.quadrature.rotPredSigmaMedian << " | "
+         << row.quadrature.posErrorMedian << " | "
+         << row.quadrature.posPredSigmaMedian << " | "
+         << row.quadrature.velErrorMedian << " | "
+         << row.quadrature.velPredSigmaMedian << " |\n";
+  }
 
-        // Compare quadrature against the two standard preintegration variants.
-        Row row;
-        row.dataset = datasetName;
-        row.interval = intervalSeconds;
-        row.samplesPerWindow = m;
-        row.quadratureNodes = N;
-        const auto windows = dataset.completeWindows(m);
-        row.quadrature = runQuadratureNees(windows, N);
-        row.manifold = runStandardNees<PIMManifold>(windows);
-        row.tangent = runStandardNees<PIMTangent>(windows);
-        rows.push_back(row);
+  // Table 2 compares median error magnitudes directly for each method.
+  cout << "\n## Table 2: Median Errors per Dataset\n\n";
+  cout << "| dataset | dt(s) | m | N"
+       << " | q_rot | m_rot | t_rot"
+       << " | q_pos | m_pos | t_pos"
+       << " | q_vel | m_vel | t_vel |\n";
+  cout << "|---|---:|---:|---:"
+       << "|---:|---:|---:"
+       << "|---:|---:|---:"
+       << "|---:|---:|---:|\n";
+  for (const auto& row : rows) {
+    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+         << row.interval << " | " << row.samplesPerWindow << " | "
+         << row.quadratureNodes << " | " << setprecision(4)
+         << row.quadrature.rotErrorMedian << " | "
+         << row.manifold.rotErrorMedian << " | " << row.tangent.rotErrorMedian
+         << " | " << row.quadrature.posErrorMedian << " | "
+         << row.manifold.posErrorMedian << " | " << row.tangent.posErrorMedian
+         << " | " << row.quadrature.velErrorMedian << " | "
+         << row.manifold.velErrorMedian << " | " << row.tangent.velErrorMedian
+         << " |\n";
+  }
 
-        cout << "[done] " << datasetName << " dt=" << fixed << setprecision(1)
-             << intervalSeconds << "s m=" << m << " N=" << N
-             << " NEES_median=" << setprecision(3) << row.quadrature.nees.median
-             << "\n";
-      }
-    }
+  // Table 3 averages the per-dataset medians to get one row per interval.
+  cout << "\n## Table 3: Aggregated Mean-of-Median Errors\n\n";
+  cout << "| dt(s) | m | N"
+       << " | q_rot | m_rot | t_rot"
+       << " | q_pos | m_pos | t_pos"
+       << " | q_vel | m_vel | t_vel |\n";
+  cout << "|---:|---:|---:"
+       << "|---:|---:|---:"
+       << "|---:|---:|---:"
+       << "|---:|---:|---:|\n";
+  for (double intervalSeconds : runner.intervals) {
+    double qRot = 0.0;
+    double mRot = 0.0;
+    double tRot = 0.0;
+    double qPos = 0.0;
+    double mPos = 0.0;
+    double tPos = 0.0;
+    double qVel = 0.0;
+    double mVel = 0.0;
+    double tVel = 0.0;
+    size_t count = 0;
+    size_t samplesPerWindow = 0;
+    size_t quadratureNodes = 0;
 
-    // Table 1 is the direct normalized-NEES comparison across the three
-    // methods.
-    cout << "\n## Table 1: Normalized NEES Median (full 9-DOF)\n\n";
-    cout << "| dataset | dt(s) | m | N | quad | manifold | tangent |\n";
-    cout << "|---|---:|---:|---:|---:|---:|---:|\n";
+    // Gather all rows that share this interval across the selected datasets.
     for (const auto& row : rows) {
-      cout << "| " << row.dataset << " | " << fixed << setprecision(1)
-           << row.interval << " | " << row.samplesPerWindow << " | "
-           << row.quadratureNodes << " | " << setprecision(3)
-           << row.quadrature.nees.median << " | " << row.manifold.nees.median
-           << " | " << row.tangent.nees.median << " |\n";
-    }
-
-    // Table 1b exposes how quadrature's observed errors compare to its
-    // covariance scale.
-    cout << "\n## Table 1b: Quad Error vs Predicted Sigma (median)\n\n";
-    cout << "| dataset | dt(s) | m | N | NEES"
-         << " | err_rot | sig_rot | err_pos | sig_pos | err_vel | sig_vel |\n";
-    cout << "|---|---:|---:|---:|---:"
-         << "|---:|---:|---:|---:|---:|---:|\n";
-    for (const auto& row : rows) {
-      cout << "| " << row.dataset << " | " << fixed << setprecision(1)
-           << row.interval << " | " << row.samplesPerWindow << " | "
-           << row.quadratureNodes << " | " << setprecision(3)
-           << row.quadrature.nees.median << " | " << setprecision(6)
-           << row.quadrature.rotErrorMedian << " | "
-           << row.quadrature.rotPredSigmaMedian << " | "
-           << row.quadrature.posErrorMedian << " | "
-           << row.quadrature.posPredSigmaMedian << " | "
-           << row.quadrature.velErrorMedian << " | "
-           << row.quadrature.velPredSigmaMedian << " |\n";
-    }
-
-    // Table 2 compares median error magnitudes directly for each method.
-    cout << "\n## Table 2: Median Errors per Dataset\n\n";
-    cout << "| dataset | dt(s) | m | N"
-         << " | q_rot | m_rot | t_rot"
-         << " | q_pos | m_pos | t_pos"
-         << " | q_vel | m_vel | t_vel |\n";
-    cout << "|---|---:|---:|---:"
-         << "|---:|---:|---:"
-         << "|---:|---:|---:"
-         << "|---:|---:|---:|\n";
-    for (const auto& row : rows) {
-      cout << "| " << row.dataset << " | " << fixed << setprecision(1)
-           << row.interval << " | " << row.samplesPerWindow << " | "
-           << row.quadratureNodes << " | " << setprecision(4)
-           << row.quadrature.rotErrorMedian << " | "
-           << row.manifold.rotErrorMedian << " | " << row.tangent.rotErrorMedian
-           << " | " << row.quadrature.posErrorMedian << " | "
-           << row.manifold.posErrorMedian << " | " << row.tangent.posErrorMedian
-           << " | " << row.quadrature.velErrorMedian << " | "
-           << row.manifold.velErrorMedian << " | " << row.tangent.velErrorMedian
-           << " |\n";
-    }
-
-    // Table 3 averages the per-dataset medians to get one row per interval.
-    cout << "\n## Table 3: Aggregated Mean-of-Median Errors\n\n";
-    cout << "| dt(s) | m | N"
-         << " | q_rot | m_rot | t_rot"
-         << " | q_pos | m_pos | t_pos"
-         << " | q_vel | m_vel | t_vel |\n";
-    cout << "|---:|---:|---:"
-         << "|---:|---:|---:"
-         << "|---:|---:|---:"
-         << "|---:|---:|---:|\n";
-    for (double intervalSeconds : intervals) {
-      double qRot = 0.0;
-      double mRot = 0.0;
-      double tRot = 0.0;
-      double qPos = 0.0;
-      double mPos = 0.0;
-      double tPos = 0.0;
-      double qVel = 0.0;
-      double mVel = 0.0;
-      double tVel = 0.0;
-      size_t count = 0;
-      size_t samplesPerWindow = 0;
-      size_t quadratureNodes = 0;
-
-      // Gather all rows that share this interval across the selected datasets.
-      for (const auto& row : rows) {
-        if (row.interval != intervalSeconds) {
-          continue;
-        }
-        samplesPerWindow = row.samplesPerWindow;
-        quadratureNodes = row.quadratureNodes;
-        qRot += row.quadrature.rotErrorMedian;
-        mRot += row.manifold.rotErrorMedian;
-        tRot += row.tangent.rotErrorMedian;
-        qPos += row.quadrature.posErrorMedian;
-        mPos += row.manifold.posErrorMedian;
-        tPos += row.tangent.posErrorMedian;
-        qVel += row.quadrature.velErrorMedian;
-        mVel += row.manifold.velErrorMedian;
-        tVel += row.tangent.velErrorMedian;
-        ++count;
-      }
-
-      if (count == 0) {
+      if (row.interval != intervalSeconds) {
         continue;
       }
-      // Normalize the accumulated medians by the number of contributing
-      // datasets.
-      const double sampleCount = static_cast<double>(count);
-      cout << "| " << fixed << setprecision(1) << intervalSeconds << " | "
-           << samplesPerWindow << " | " << quadratureNodes << " | "
-           << setprecision(4) << qRot / sampleCount << " | "
-           << mRot / sampleCount << " | " << tRot / sampleCount << " | "
-           << qPos / sampleCount << " | " << mPos / sampleCount << " | "
-           << tPos / sampleCount << " | " << qVel / sampleCount << " | "
-           << mVel / sampleCount << " | " << tVel / sampleCount << " |\n";
+      samplesPerWindow = row.samplesPerWindow;
+      quadratureNodes = row.quadratureNodes;
+      qRot += row.quadrature.rotErrorMedian;
+      mRot += row.manifold.rotErrorMedian;
+      tRot += row.tangent.rotErrorMedian;
+      qPos += row.quadrature.posErrorMedian;
+      mPos += row.manifold.posErrorMedian;
+      tPos += row.tangent.posErrorMedian;
+      qVel += row.quadrature.velErrorMedian;
+      mVel += row.manifold.velErrorMedian;
+      tVel += row.tangent.velErrorMedian;
+      ++count;
     }
 
-    return 0;
-  } catch (const exception& error) {
-    cerr << "Error: " << error.what() << "\n";
-    return 1;
+    if (count == 0) {
+      continue;
+    }
+    // Normalize the accumulated medians by the number of contributing
+    // datasets.
+    const double sampleCount = static_cast<double>(count);
+    cout << "| " << fixed << setprecision(1) << intervalSeconds << " | "
+         << samplesPerWindow << " | " << quadratureNodes << " | "
+         << setprecision(4) << qRot / sampleCount << " | " << mRot / sampleCount
+         << " | " << tRot / sampleCount << " | " << qPos / sampleCount << " | "
+         << mPos / sampleCount << " | " << tPos / sampleCount << " | "
+         << qVel / sampleCount << " | " << mVel / sampleCount << " | "
+         << tVel / sampleCount << " |\n";
   }
+
+  return 0;
 }

--- a/apps/evalQuadratureImuFactorDiagnostics.cpp
+++ b/apps/evalQuadratureImuFactorDiagnostics.cpp
@@ -201,8 +201,9 @@ AppOptions parseAppArguments(const vector<string>& arguments,
 }
 
 struct RunForDataset {
-  explicit RunForDataset(vector<double> intervals)
-      : intervals(std::move(intervals)) {}
+  explicit RunForDataset(const AppOptions& options)
+      : intervals(selectIntervals(defaultQuadratureIntervals(),
+                                  options.maxIntervals)) {}
 
   vector<double> intervals;
   vector<Row> rows;
@@ -231,141 +232,136 @@ struct RunForDataset {
            << "\n";
     }
   }
+
+  void report() const {
+    // Table 1 is the direct normalized-NEES comparison across the three
+    // methods.
+    cout << "\n## Table 1: Normalized NEES Median (full 9-DOF)\n\n";
+    cout << "| dataset | dt(s) | m | N | quad | manifold | tangent |\n";
+    cout << "|---|---:|---:|---:|---:|---:|---:|\n";
+    for (const auto& row : rows) {
+      cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+           << row.interval << " | " << row.samplesPerWindow << " | "
+           << row.quadratureNodes << " | " << setprecision(3)
+           << row.quadrature.nees.median << " | " << row.manifold.nees.median
+           << " | " << row.tangent.nees.median << " |\n";
+    }
+
+    // Table 1b exposes how quadrature's observed errors compare to its
+    // covariance scale.
+    cout << "\n## Table 1b: Quad Error vs Predicted Sigma (median)\n\n";
+    cout << "| dataset | dt(s) | m | N | NEES"
+         << " | err_rot | sig_rot | err_pos | sig_pos | err_vel | sig_vel |\n";
+    cout << "|---|---:|---:|---:|---:"
+         << "|---:|---:|---:|---:|---:|---:|\n";
+    for (const auto& row : rows) {
+      cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+           << row.interval << " | " << row.samplesPerWindow << " | "
+           << row.quadratureNodes << " | " << setprecision(3)
+           << row.quadrature.nees.median << " | " << setprecision(6)
+           << row.quadrature.rotErrorMedian << " | "
+           << row.quadrature.rotPredSigmaMedian << " | "
+           << row.quadrature.posErrorMedian << " | "
+           << row.quadrature.posPredSigmaMedian << " | "
+           << row.quadrature.velErrorMedian << " | "
+           << row.quadrature.velPredSigmaMedian << " |\n";
+    }
+
+    // Table 2 compares median error magnitudes directly for each method.
+    cout << "\n## Table 2: Median Errors per Dataset\n\n";
+    cout << "| dataset | dt(s) | m | N"
+         << " | q_rot | m_rot | t_rot"
+         << " | q_pos | m_pos | t_pos"
+         << " | q_vel | m_vel | t_vel |\n";
+    cout << "|---|---:|---:|---:"
+         << "|---:|---:|---:"
+         << "|---:|---:|---:"
+         << "|---:|---:|---:|\n";
+    for (const auto& row : rows) {
+      cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+           << row.interval << " | " << row.samplesPerWindow << " | "
+           << row.quadratureNodes << " | " << setprecision(4)
+           << row.quadrature.rotErrorMedian << " | "
+           << row.manifold.rotErrorMedian << " | " << row.tangent.rotErrorMedian
+           << " | " << row.quadrature.posErrorMedian << " | "
+           << row.manifold.posErrorMedian << " | " << row.tangent.posErrorMedian
+           << " | " << row.quadrature.velErrorMedian << " | "
+           << row.manifold.velErrorMedian << " | " << row.tangent.velErrorMedian
+           << " |\n";
+    }
+
+    // Table 3 averages the per-dataset medians to get one row per interval.
+    cout << "\n## Table 3: Aggregated Mean-of-Median Errors\n\n";
+    cout << "| dt(s) | m | N"
+         << " | q_rot | m_rot | t_rot"
+         << " | q_pos | m_pos | t_pos"
+         << " | q_vel | m_vel | t_vel |\n";
+    cout << "|---:|---:|---:"
+         << "|---:|---:|---:"
+         << "|---:|---:|---:"
+         << "|---:|---:|---:|\n";
+    for (double intervalSeconds : intervals) {
+      double qRot = 0.0;
+      double mRot = 0.0;
+      double tRot = 0.0;
+      double qPos = 0.0;
+      double mPos = 0.0;
+      double tPos = 0.0;
+      double qVel = 0.0;
+      double mVel = 0.0;
+      double tVel = 0.0;
+      size_t count = 0;
+      size_t samplesPerWindow = 0;
+      size_t quadratureNodes = 0;
+
+      // Gather all rows that share this interval across the selected datasets.
+      for (const auto& row : rows) {
+        if (row.interval != intervalSeconds) {
+          continue;
+        }
+        samplesPerWindow = row.samplesPerWindow;
+        quadratureNodes = row.quadratureNodes;
+        qRot += row.quadrature.rotErrorMedian;
+        mRot += row.manifold.rotErrorMedian;
+        tRot += row.tangent.rotErrorMedian;
+        qPos += row.quadrature.posErrorMedian;
+        mPos += row.manifold.posErrorMedian;
+        tPos += row.tangent.posErrorMedian;
+        qVel += row.quadrature.velErrorMedian;
+        mVel += row.manifold.velErrorMedian;
+        tVel += row.tangent.velErrorMedian;
+        ++count;
+      }
+
+      if (count == 0) {
+        continue;
+      }
+      // Normalize the accumulated medians by the number of contributing
+      // datasets.
+      const double sampleCount = static_cast<double>(count);
+      cout << "| " << fixed << setprecision(1) << intervalSeconds << " | "
+           << samplesPerWindow << " | " << quadratureNodes << " | "
+           << setprecision(4) << qRot / sampleCount << " | "
+           << mRot / sampleCount << " | " << tRot / sampleCount << " | "
+           << qPos / sampleCount << " | " << mPos / sampleCount << " | "
+           << tPos / sampleCount << " | " << qVel / sampleCount << " | "
+           << mVel / sampleCount << " | " << tVel / sampleCount << " |\n";
+    }
+  }
 };
 
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  // Resolve the datasets and interval subset requested on the command line.
   const auto datasetCli = resolveDatasetAppCli(argc, argv);
   const AppOptions appOptions =
       parseAppArguments(datasetCli.remainingArgs, argv[0]);
 
-  const vector<double> defaultIntervals = defaultQuadratureIntervals();
-  const vector<double> intervals =
-      selectIntervals(defaultIntervals, appOptions.maxIntervals);
-
-  // Evaluate all requested datasets and window lengths.
-  RunForDataset runner(intervals);
+  RunForDataset runner(appOptions);
   const int status = runForDatasets(datasetCli, runner);
   if (status != 0) {
     return status;
   }
-  const vector<Row>& rows = runner.rows;
-
-  // Table 1 is the direct normalized-NEES comparison across the three
-  // methods.
-  cout << "\n## Table 1: Normalized NEES Median (full 9-DOF)\n\n";
-  cout << "| dataset | dt(s) | m | N | quad | manifold | tangent |\n";
-  cout << "|---|---:|---:|---:|---:|---:|---:|\n";
-  for (const auto& row : rows) {
-    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
-         << row.interval << " | " << row.samplesPerWindow << " | "
-         << row.quadratureNodes << " | " << setprecision(3)
-         << row.quadrature.nees.median << " | " << row.manifold.nees.median
-         << " | " << row.tangent.nees.median << " |\n";
-  }
-
-  // Table 1b exposes how quadrature's observed errors compare to its
-  // covariance scale.
-  cout << "\n## Table 1b: Quad Error vs Predicted Sigma (median)\n\n";
-  cout << "| dataset | dt(s) | m | N | NEES"
-       << " | err_rot | sig_rot | err_pos | sig_pos | err_vel | sig_vel |\n";
-  cout << "|---|---:|---:|---:|---:"
-       << "|---:|---:|---:|---:|---:|---:|\n";
-  for (const auto& row : rows) {
-    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
-         << row.interval << " | " << row.samplesPerWindow << " | "
-         << row.quadratureNodes << " | " << setprecision(3)
-         << row.quadrature.nees.median << " | " << setprecision(6)
-         << row.quadrature.rotErrorMedian << " | "
-         << row.quadrature.rotPredSigmaMedian << " | "
-         << row.quadrature.posErrorMedian << " | "
-         << row.quadrature.posPredSigmaMedian << " | "
-         << row.quadrature.velErrorMedian << " | "
-         << row.quadrature.velPredSigmaMedian << " |\n";
-  }
-
-  // Table 2 compares median error magnitudes directly for each method.
-  cout << "\n## Table 2: Median Errors per Dataset\n\n";
-  cout << "| dataset | dt(s) | m | N"
-       << " | q_rot | m_rot | t_rot"
-       << " | q_pos | m_pos | t_pos"
-       << " | q_vel | m_vel | t_vel |\n";
-  cout << "|---|---:|---:|---:"
-       << "|---:|---:|---:"
-       << "|---:|---:|---:"
-       << "|---:|---:|---:|\n";
-  for (const auto& row : rows) {
-    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
-         << row.interval << " | " << row.samplesPerWindow << " | "
-         << row.quadratureNodes << " | " << setprecision(4)
-         << row.quadrature.rotErrorMedian << " | "
-         << row.manifold.rotErrorMedian << " | " << row.tangent.rotErrorMedian
-         << " | " << row.quadrature.posErrorMedian << " | "
-         << row.manifold.posErrorMedian << " | " << row.tangent.posErrorMedian
-         << " | " << row.quadrature.velErrorMedian << " | "
-         << row.manifold.velErrorMedian << " | " << row.tangent.velErrorMedian
-         << " |\n";
-  }
-
-  // Table 3 averages the per-dataset medians to get one row per interval.
-  cout << "\n## Table 3: Aggregated Mean-of-Median Errors\n\n";
-  cout << "| dt(s) | m | N"
-       << " | q_rot | m_rot | t_rot"
-       << " | q_pos | m_pos | t_pos"
-       << " | q_vel | m_vel | t_vel |\n";
-  cout << "|---:|---:|---:"
-       << "|---:|---:|---:"
-       << "|---:|---:|---:"
-       << "|---:|---:|---:|\n";
-  for (double intervalSeconds : runner.intervals) {
-    double qRot = 0.0;
-    double mRot = 0.0;
-    double tRot = 0.0;
-    double qPos = 0.0;
-    double mPos = 0.0;
-    double tPos = 0.0;
-    double qVel = 0.0;
-    double mVel = 0.0;
-    double tVel = 0.0;
-    size_t count = 0;
-    size_t samplesPerWindow = 0;
-    size_t quadratureNodes = 0;
-
-    // Gather all rows that share this interval across the selected datasets.
-    for (const auto& row : rows) {
-      if (row.interval != intervalSeconds) {
-        continue;
-      }
-      samplesPerWindow = row.samplesPerWindow;
-      quadratureNodes = row.quadratureNodes;
-      qRot += row.quadrature.rotErrorMedian;
-      mRot += row.manifold.rotErrorMedian;
-      tRot += row.tangent.rotErrorMedian;
-      qPos += row.quadrature.posErrorMedian;
-      mPos += row.manifold.posErrorMedian;
-      tPos += row.tangent.posErrorMedian;
-      qVel += row.quadrature.velErrorMedian;
-      mVel += row.manifold.velErrorMedian;
-      tVel += row.tangent.velErrorMedian;
-      ++count;
-    }
-
-    if (count == 0) {
-      continue;
-    }
-    // Normalize the accumulated medians by the number of contributing
-    // datasets.
-    const double sampleCount = static_cast<double>(count);
-    cout << "| " << fixed << setprecision(1) << intervalSeconds << " | "
-         << samplesPerWindow << " | " << quadratureNodes << " | "
-         << setprecision(4) << qRot / sampleCount << " | " << mRot / sampleCount
-         << " | " << tRot / sampleCount << " | " << qPos / sampleCount << " | "
-         << mPos / sampleCount << " | " << tPos / sampleCount << " | "
-         << qVel / sampleCount << " | " << mVel / sampleCount << " | "
-         << tVel / sampleCount << " |\n";
-  }
-
+  runner.report();
   return 0;
 }

--- a/apps/evalQuadratureImuFactorDiagnostics.cpp
+++ b/apps/evalQuadratureImuFactorDiagnostics.cpp
@@ -14,10 +14,8 @@
  */
 
 #include <gtsam/base/Vector.h>
-#include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/ImuFactor.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
-#include <gtsam/navigation/QuadratureImuFactor.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 
 #include <cmath>
@@ -38,13 +36,8 @@ using namespace gtsam;
 using namespace std;
 
 using PIMQuadrature = PreintegratedImuMeasurementsQ;
-using QuadratureImuFactor = ImuFactorT<PreintegratedImuMeasurementsQ>;
 using PIMTangent = PreintegratedImuMeasurementsT<TangentPreintegration>;
 using PIMManifold = PreintegratedImuMeasurementsT<ManifoldPreintegration>;
-
-using symbol_shorthand::B;
-using symbol_shorthand::V;
-using symbol_shorthand::X;
 
 namespace {
 
@@ -74,22 +67,11 @@ struct Summary {
   size_t nodeCount = 0;
 };
 
-// Raw per-window measurements before they are collapsed into medians.
-struct MethodSample {
-  double normalizedNees = 0.0;
-  double rotErrorNorm = 0.0;
-  double rotPredSigma = 0.0;
-  double posErrorNorm = 0.0;
-  double posPredSigma = 0.0;
-  double velErrorNorm = 0.0;
-  double velPredSigma = 0.0;
-};
-
 // Hold all samples for one method and summarize them in one place.
 struct MethodSamples {
-  vector<MethodSample> values;
+  vector<WindowResult> values;
 
-  void append(const MethodSample& sample) { values.push_back(sample); }
+  void append(const WindowResult& sample) { values.push_back(sample); }
 
   Summary summarize(size_t nodeCount = 0) const;
 };
@@ -111,12 +93,6 @@ shared_ptr<PreintegrationParams> createPreintegrationParams() {
   params->gyroscopeCovariance = I_3x3 * kSigmaGyro * kSigmaGyro;
   params->integrationCovariance = I_3x3 * 1e-8;
   return params;
-}
-
-double covarianceBlockSigma(const Matrix9& covariance, int blockStart) {
-  // Convert a 3x3 covariance block into a scalar sigma proxy via RMS variance.
-  return std::sqrt(std::max(
-      0.0, covariance.block<3, 3>(blockStart, blockStart).trace() / 3.0));
 }
 
 NeesStats summarizeNormalizedNees(const vector<double>& normalizedNeesValues) {
@@ -152,82 +128,22 @@ Summary MethodSamples::summarize(size_t nodeCount) const {
   };
 
   const vector<double> normalizedNeesValues =
-      project(&MethodSample::normalizedNees);
+      project(&WindowResult::normalizedNees);
   summary.nees = summarizeNormalizedNees(normalizedNeesValues);
   summary.rotErrorMedian =
-      summarizeMedian(project(&MethodSample::rotErrorNorm));
+      summarizeMedian(project(&WindowResult::rotErrorNorm));
   summary.rotPredSigmaMedian =
-      summarizeMedian(project(&MethodSample::rotPredSigma));
+      summarizeMedian(project(&WindowResult::rotPredSigma));
   summary.posErrorMedian =
-      summarizeMedian(project(&MethodSample::posErrorNorm));
+      summarizeMedian(project(&WindowResult::posErrorNorm));
   summary.posPredSigmaMedian =
-      summarizeMedian(project(&MethodSample::posPredSigma));
+      summarizeMedian(project(&WindowResult::posPredSigma));
   summary.velErrorMedian =
-      summarizeMedian(project(&MethodSample::velErrorNorm));
+      summarizeMedian(project(&WindowResult::velErrorNorm));
   summary.velPredSigmaMedian =
-      summarizeMedian(project(&MethodSample::velPredSigma));
+      summarizeMedian(project(&WindowResult::velPredSigma));
   summary.samples = summary.nees.samples;
   return summary;
-}
-
-MethodSample makeMethodSample(const Vector9& error, const Matrix9& covariance,
-                              double normalizedNees) {
-  MethodSample sample;
-  sample.normalizedNees = normalizedNees;
-  sample.rotErrorNorm = error.head<3>().norm();
-  sample.rotPredSigma = covarianceBlockSigma(covariance, 0);
-  sample.posErrorNorm = error.segment<3>(3).norm();
-  sample.posPredSigma = covarianceBlockSigma(covariance, 3);
-  sample.velErrorNorm = error.tail<3>().norm();
-  sample.velPredSigma = covarianceBlockSigma(covariance, 6);
-  return sample;
-}
-
-optional<MethodSample> analyzeQuadratureWindow(
-    const Window& window, const shared_ptr<PreintegrationParams>& params,
-    size_t N) {
-  // Run quadrature preintegration on one window and close the integration
-  // interval.
-  const PIMQuadrature preintegrated = buildPreintegrated<PIMQuadrature>(
-      window, params, window.initialTruth().bias, N);
-
-  // Evaluate the factor at ground truth to get the residual and predicted
-  // covariance.
-  const Matrix9 covariance = preintegrated.preintMeasCov();
-  QuadratureImuFactor factor(X(1), V(1), X(2), V(2), B(1), preintegrated);
-  const Vector9 error = factor.evaluateError(
-      window.initialTruth().navState.pose(),
-      window.initialTruth().navState.velocity(),
-      window.terminalTruth().navState.pose(),
-      window.terminalTruth().navState.velocity(), window.initialTruth().bias);
-
-  const auto normalizedNees = normalizedNEES(error, covariance, 9.0);
-  if (!normalizedNees || !std::isfinite(*normalizedNees)) {
-    return nullopt;
-  }
-  return makeMethodSample(error, covariance, *normalizedNees);
-}
-
-template <class PIMType>
-optional<MethodSample> analyzeStandardWindow(
-    const Window& window, const shared_ptr<PreintegrationParams>& params) {
-  // Run the standard manifold or tangent preintegration on one window.
-  const PIMType preintegrated =
-      buildPreintegrated<PIMType>(window, params, window.initialTruth().bias);
-
-  // The standard factor exposes the same 9D residual, so we summarize it
-  // identically.
-  ImuFactor2T<PIMType> factor(X(1), X(2), B(1), preintegrated);
-  const Vector9 error = factor.evaluateError(window.initialTruth().navState,
-                                             window.terminalTruth().navState,
-                                             window.initialTruth().bias);
-  const Matrix9 covariance = preintegrated.preintMeasCov();
-
-  const auto normalizedNees = normalizedNEES(error, covariance, 9.0);
-  if (!normalizedNees || !std::isfinite(*normalizedNees)) {
-    return nullopt;
-  }
-  return makeMethodSample(error, covariance, *normalizedNees);
 }
 
 Summary runQuadratureNees(const vector<Window>& windows,
@@ -237,8 +153,8 @@ Summary runQuadratureNees(const vector<Window>& windows,
 
   // Accumulate one sample per valid window for the quadrature method.
   for (const auto& window : windows) {
-    const auto sample =
-        analyzeQuadratureWindow(window, params, quadratureNodes);
+    const auto sample = evaluateWindow<PIMQuadrature>(
+        window, params, std::nullopt, quadratureNodes);
     if (sample) samples.append(*sample);
   }
 
@@ -252,7 +168,7 @@ Summary runStandardNees(const vector<Window>& windows) {
 
   // Accumulate one sample per valid window for the chosen standard method.
   for (const auto& window : windows) {
-    const auto sample = analyzeStandardWindow<PIMType>(window, params);
+    const auto sample = evaluateWindow<PIMType>(window, params);
     if (sample) samples.append(*sample);
   }
 

--- a/apps/evalReducedNeesWithPriorCovariance.cpp
+++ b/apps/evalReducedNeesWithPriorCovariance.cpp
@@ -14,10 +14,8 @@
  */
 
 #include <gtsam/base/Vector.h>
-#include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/ImuFactor.h>
 #include <gtsam/navigation/ManifoldPreintegration.h>
-#include <gtsam/navigation/QuadratureImuFactor.h>
 #include <gtsam/navigation/TangentPreintegration.h>
 
 #include <cmath>
@@ -38,13 +36,8 @@ using namespace gtsam;
 using namespace std;
 
 using PIMQuadrature = PreintegratedImuMeasurementsQ;
-using QuadratureImuFactor = ImuFactorT<PreintegratedImuMeasurementsQ>;
 using PIMTangent = PreintegratedImuMeasurementsT<TangentPreintegration>;
 using PIMManifold = PreintegratedImuMeasurementsT<ManifoldPreintegration>;
-
-using symbol_shorthand::B;
-using symbol_shorthand::V;
-using symbol_shorthand::X;
 
 namespace {
 
@@ -98,93 +91,23 @@ Summary summarizeNormalizedNees(const vector<double>& normalizedNeesValues) {
   return summary;
 }
 
-Vector9 computeQuadratureDeltaForBias(
-    const Window& window, const shared_ptr<PreintegrationParams>& params,
-    size_t quadratureOrder, const imuBias::ConstantBias& bias) {
-  // Convert quadrature's preintegrated state into the 9D residual space used by
-  // NEES.
-  const auto preintegrated =
-      buildPreintegrated<PIMQuadrature>(window, params, bias, quadratureOrder);
-
-  Vector9 delta;
-  delta << preintegrated.deltaRij().logmap(Rot3()), preintegrated.deltaPij(),
-      preintegrated.deltaVij();
-  return delta;
-}
-
 optional<double> computeQuadratureNormalizedNeesForWindow(
     const Window& window, const shared_ptr<PreintegrationParams>& params,
     size_t N) {
-  const imuBias::ConstantBias& initialBias = window.initialTruth().bias;
-  // Start from the nominal quadrature preintegration at the ground-truth bias.
-  auto preintegrated =
-      buildPreintegrated<PIMQuadrature>(window, params, initialBias, N);
-
-  // Approximate the bias Jacobian numerically because the quadrature path does
-  // not expose it.
-  constexpr double kBiasPerturbation = 1e-5;
-  Matrix96 biasJacobian;
-  const Vector6 biasVector = initialBias.vector();
-  for (int column = 0; column < 6; ++column) {
-    Vector6 plusBias = biasVector;
-    Vector6 minusBias = biasVector;
-    plusBias(column) += kBiasPerturbation;
-    minusBias(column) -= kBiasPerturbation;
-
-    const Vector9 deltaPlus = computeQuadratureDeltaForBias(
-        window, params, N,
-        imuBias::ConstantBias(plusBias.head<3>(), plusBias.tail<3>()));
-    const Vector9 deltaMinus = computeQuadratureDeltaForBias(
-        window, params, N,
-        imuBias::ConstantBias(minusBias.head<3>(), minusBias.tail<3>()));
-    biasJacobian.col(column) =
-        (deltaPlus - deltaMinus) / (2.0 * kBiasPerturbation);
-  }
-
-  // Fold initial state and bias cov into covariance before scoring NEES.
-  preintegrated.setInitialCovariance(initialNavCovariance() +
-                                     biasJacobian * initialBiasCovariance() *
-                                         biasJacobian.transpose());
-
-  QuadratureImuFactor factor(X(1), V(1), X(2), V(2), B(1), preintegrated);
-  const Vector9 error = factor.evaluateError(
-      window.initialTruth().navState.pose(),
-      window.initialTruth().navState.velocity(),
-      window.terminalTruth().navState.pose(),
-      window.terminalTruth().navState.velocity(), initialBias);
-  const auto normalizedNees =
-      normalizedNEES(error, preintegrated.preintMeasCov(), 9.0);
-  if (!normalizedNees || !std::isfinite(*normalizedNees)) {
-    return nullopt;
-  }
-  return *normalizedNees;
+  const InitialCovarianceOptions initialCovariance{
+      initialNavCovariance(), initialBiasCovariance()};
+  const auto result =
+      evaluateWindow<PIMQuadrature>(window, params, initialCovariance, N);
+  return result ? optional<double>(result->normalizedNees) : nullopt;
 }
 
 template <class PIMType>
 optional<double> computeStandardNormalizedNeesForWindow(
     const Window& window, const shared_ptr<PreintegrationParams>& params) {
-  const imuBias::ConstantBias& initialBias = window.initialTruth().bias;
-  // Start from the nominal standard preintegration at the ground-truth bias.
-  auto preintegrated = buildPreintegrated<PIMType>(window, params, initialBias);
-
-  // Standard preintegration provides the bias Jacobian directly.
-  Matrix96 biasJacobian;
-  preintegrated.biasCorrectedDelta(initialBias, biasJacobian);
-  const Matrix9 totalCovariance =
-      preintegrated.preintMeasCov() + initialNavCovariance() +
-      biasJacobian * initialBiasCovariance() * biasJacobian.transpose();
-  preintegrated.setPreintMeasCov(totalCovariance);
-
-  ImuFactor2T<PIMType> factor(X(1), X(2), B(1), preintegrated);
-  const Vector9 error =
-      factor.evaluateError(window.initialTruth().navState,
-                           window.terminalTruth().navState, initialBias);
-  const auto normalizedNees =
-      normalizedNEES(error, preintegrated.preintMeasCov(), 9.0);
-  if (!normalizedNees || !std::isfinite(*normalizedNees)) {
-    return nullopt;
-  }
-  return *normalizedNees;
+  const InitialCovarianceOptions initialCovariance{
+      initialNavCovariance(), initialBiasCovariance()};
+  const auto result = evaluateWindow<PIMType>(window, params, initialCovariance);
+  return result ? optional<double>(result->normalizedNees) : nullopt;
 }
 
 Summary runQuadratureNormalizedNees(const vector<Window>& windows,

--- a/apps/evalReducedNeesWithPriorCovariance.cpp
+++ b/apps/evalReducedNeesWithPriorCovariance.cpp
@@ -94,8 +94,8 @@ Summary summarizeNormalizedNees(const vector<double>& normalizedNeesValues) {
 optional<double> computeQuadratureNormalizedNeesForWindow(
     const Window& window, const shared_ptr<PreintegrationParams>& params,
     size_t N) {
-  const InitialCovarianceOptions initialCovariance{
-      initialNavCovariance(), initialBiasCovariance()};
+  const InitialCovarianceOptions initialCovariance{initialNavCovariance(),
+                                                   initialBiasCovariance()};
   const auto result =
       evaluateWindow<PIMQuadrature>(window, params, initialCovariance, N);
   return result ? optional<double>(result->normalizedNees) : nullopt;
@@ -104,9 +104,10 @@ optional<double> computeQuadratureNormalizedNeesForWindow(
 template <class PIMType>
 optional<double> computeStandardNormalizedNeesForWindow(
     const Window& window, const shared_ptr<PreintegrationParams>& params) {
-  const InitialCovarianceOptions initialCovariance{
-      initialNavCovariance(), initialBiasCovariance()};
-  const auto result = evaluateWindow<PIMType>(window, params, initialCovariance);
+  const InitialCovarianceOptions initialCovariance{initialNavCovariance(),
+                                                   initialBiasCovariance()};
+  const auto result =
+      evaluateWindow<PIMType>(window, params, initialCovariance);
   return result ? optional<double>(result->normalizedNees) : nullopt;
 }
 
@@ -141,61 +142,102 @@ Summary runStandardNormalizedNees(const vector<Window>& windows) {
 
   return summarizeNormalizedNees(normalizedNeesValues);
 }
+
+struct AppOptions {
+  size_t maxIntervals = 0;
+};
+
+struct Row {
+  string dataset;
+  double interval = 0.0;
+  size_t samplesPerWindow = 0;
+  size_t quadratureNodes = 0;
+  Summary quadrature;
+  Summary manifold;
+  Summary tangent;
+};
+
+void printUsage(const char* programName) {
+  cout << "Usage: " << programName
+       << " [--data-dir <path>] [--dataset <name>] [--max-intervals <count>]\n";
+  cout << "  --data-dir <path>       Dataset directory (default: "
+          "../data/euroc/)\n";
+  cout << "  --dataset <name>        Restrict to one dataset (e.g. MH01 or "
+          "euroc_MH01.csv)\n";
+  cout << "  --max-intervals <count> Restrict to first N default intervals\n";
+}
+
+AppOptions parseAppArguments(const vector<string>& arguments,
+                             const char* programName) {
+  for (const string& argument : arguments) {
+    if (isHelpArgument(argument)) {
+      printUsage(programName);
+      std::exit(0);
+    }
+  }
+  return {parseMaxIntervalsArgument(arguments)};
+}
+
+struct RunForDataset {
+  explicit RunForDataset(vector<double> intervals)
+      : intervals(std::move(intervals)) {}
+
+  vector<double> intervals;
+  vector<Row> rows;
+
+  void operator()(const string& datasetName, const Dataset& dataset) {
+    for (double intervalSeconds : intervals) {
+      const size_t m = dataset.stepsForInterval(intervalSeconds);
+      const size_t N = max<size_t>(
+          3, static_cast<size_t>(floor(sqrt(static_cast<double>(m)))));
+
+      // Compare the prior-aware normalized-NEES score across all three
+      // methods.
+      const auto windows = dataset.completeWindows(m);
+      Row row;
+      row.dataset = datasetName;
+      row.interval = intervalSeconds;
+      row.samplesPerWindow = m;
+      row.quadratureNodes = N;
+      row.quadrature = runQuadratureNormalizedNees(windows, N);
+      row.manifold = runStandardNormalizedNees<PIMManifold>(windows);
+      row.tangent = runStandardNormalizedNees<PIMTangent>(windows);
+      rows.push_back(row);
+    }
+  }
+};
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  try {
-    // Resolve the datasets and interval subset requested on the command line.
-    const AppCliOptions options = parseDatasetAppCliOptions(argc, argv);
-    const vector<pair<string, string>> discoveredDatasets =
-        discoverFilteredDatasets(options.dataDirectory, DatasetFilters::all);
-    const vector<pair<string, string>> datasets =
-        selectDatasets(discoveredDatasets, options.datasetName);
+  // Resolve the datasets and interval subset requested on the command line.
+  const auto datasetCli = resolveDatasetAppCli(argc, argv);
+  const AppOptions appOptions =
+      parseAppArguments(datasetCli.remainingArgs, argv[0]);
 
-    if (datasets.empty()) {
-      cerr << "No datasets found in " << options.dataDirectory << "\n";
-      return 1;
-    }
+  const vector<double> defaultIntervals = defaultQuadratureIntervals();
+  const vector<double> intervals =
+      selectIntervals(defaultIntervals, appOptions.maxIntervals);
 
-    const vector<double> defaultIntervals = defaultQuadratureIntervals();
-    const vector<double> intervals =
-        selectIntervals(defaultIntervals, options.maxIntervals);
+  // Print a compact one-table summary comparing normalized NEES.
+  cout << "# Quadrature vs Manifold vs Tangent normalized NEES\n";
+  cout << "# alpha=" << kAlpha << " sigma_gyro=" << kSigmaGyro
+       << " sigma_acc=" << kSigmaAcc << "\n\n";
+  cout << "| dataset | dt(s) | m | N | Quadrature | Manifold | Tangent |\n";
+  cout << "|---|---:|---:|---:|---:|---:|---:|\n";
 
-    // Print a compact one-table summary comparing normalized NEES.
-    cout << "# Quadrature vs Manifold vs Tangent normalized NEES\n";
-    cout << "# alpha=" << kAlpha << " sigma_gyro=" << kSigmaGyro
-         << " sigma_acc=" << kSigmaAcc << "\n\n";
-    cout << "| dataset | dt(s) | m | N | Quadrature | Manifold | Tangent |\n";
-    cout << "|---|---:|---:|---:|---:|---:|---:|\n";
-
-    for (const auto& datasetEntry : datasets) {
-      const string& datasetPath = datasetEntry.second;
-      Dataset dataset(datasetPath);
-      if (dataset.truth.size() < 2) continue;
-      const string& datasetName = datasetEntry.first;
-
-      for (double intervalSeconds : intervals) {
-        const size_t m = dataset.stepsForInterval(intervalSeconds);
-        const size_t N = max<size_t>(
-            3, static_cast<size_t>(floor(sqrt(static_cast<double>(m)))));
-
-        // Compare the prior-aware normalized-NEES score across all three
-        // methods.
-        const auto windows = dataset.completeWindows(m);
-        const Summary quadrature = runQuadratureNormalizedNees(windows, N);
-        const Summary manifold = runStandardNormalizedNees<PIMManifold>(windows);
-        const Summary tangent = runStandardNormalizedNees<PIMTangent>(windows);
-
-        cout << "| " << datasetName << " | " << fixed << setprecision(1)
-             << intervalSeconds << " | " << m << " | " << N << " | "
-             << setprecision(3) << quadrature.normalizedNeesMedian << " | "
-             << manifold.normalizedNeesMedian << " | "
-             << tangent.normalizedNeesMedian << " |\n";
-      }
-    }
-    return 0;
-  } catch (const exception& error) {
-    cerr << "Error: " << error.what() << "\n";
-    return 1;
+  RunForDataset runner(intervals);
+  const int status = runForDatasets(datasetCli, runner);
+  if (status != 0) {
+    return status;
   }
+
+  for (const auto& row : runner.rows) {
+    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+         << row.interval << " | " << row.samplesPerWindow << " | "
+         << row.quadratureNodes << " | " << setprecision(3)
+         << row.quadrature.normalizedNeesMedian << " | "
+         << row.manifold.normalizedNeesMedian << " | "
+         << row.tangent.normalizedNeesMedian << " |\n";
+  }
+  return 0;
 }

--- a/apps/evalReducedNeesWithPriorCovariance.cpp
+++ b/apps/evalReducedNeesWithPriorCovariance.cpp
@@ -179,8 +179,9 @@ AppOptions parseAppArguments(const vector<string>& arguments,
 }
 
 struct RunForDataset {
-  explicit RunForDataset(vector<double> intervals)
-      : intervals(std::move(intervals)) {}
+  explicit RunForDataset(const AppOptions& options)
+      : intervals(selectIntervals(defaultQuadratureIntervals(),
+                                  options.maxIntervals)) {}
 
   vector<double> intervals;
   vector<Row> rows;
@@ -191,8 +192,7 @@ struct RunForDataset {
       const size_t N = max<size_t>(
           3, static_cast<size_t>(floor(sqrt(static_cast<double>(m)))));
 
-      // Compare the prior-aware normalized-NEES score across all three
-      // methods.
+      // Compare the prior-aware normalized-NEES score across all methods.
       const auto windows = dataset.completeWindows(m);
       Row row;
       row.dataset = datasetName;
@@ -205,39 +205,36 @@ struct RunForDataset {
       rows.push_back(row);
     }
   }
+
+  void report() const {
+    cout << "# Quadrature vs Manifold vs Tangent normalized NEES\n";
+    cout << "# alpha=" << kAlpha << " sigma_gyro=" << kSigmaGyro
+         << " sigma_acc=" << kSigmaAcc << "\n\n";
+    cout << "| dataset | dt(s) | m | N | Quadrature | Manifold | Tangent |\n";
+    cout << "|---|---:|---:|---:|---:|---:|---:|\n";
+
+    for (const auto& row : rows) {
+      cout << "| " << row.dataset << " | " << fixed << setprecision(1)
+           << row.interval << " | " << row.samplesPerWindow << " | "
+           << row.quadratureNodes << " | " << setprecision(3)
+           << row.quadrature.normalizedNeesMedian << " | "
+           << row.manifold.normalizedNeesMedian << " | "
+           << row.tangent.normalizedNeesMedian << " |\n";
+    }
+  }
 };
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  // Resolve the datasets and interval subset requested on the command line.
   const auto datasetCli = resolveDatasetAppCli(argc, argv);
   const AppOptions appOptions =
       parseAppArguments(datasetCli.remainingArgs, argv[0]);
 
-  const vector<double> defaultIntervals = defaultQuadratureIntervals();
-  const vector<double> intervals =
-      selectIntervals(defaultIntervals, appOptions.maxIntervals);
-
-  // Print a compact one-table summary comparing normalized NEES.
-  cout << "# Quadrature vs Manifold vs Tangent normalized NEES\n";
-  cout << "# alpha=" << kAlpha << " sigma_gyro=" << kSigmaGyro
-       << " sigma_acc=" << kSigmaAcc << "\n\n";
-  cout << "| dataset | dt(s) | m | N | Quadrature | Manifold | Tangent |\n";
-  cout << "|---|---:|---:|---:|---:|---:|---:|\n";
-
-  RunForDataset runner(intervals);
+  RunForDataset runner(appOptions);
   const int status = runForDatasets(datasetCli, runner);
   if (status != 0) {
     return status;
   }
-
-  for (const auto& row : runner.rows) {
-    cout << "| " << row.dataset << " | " << fixed << setprecision(1)
-         << row.interval << " | " << row.samplesPerWindow << " | "
-         << row.quadratureNodes << " | " << setprecision(3)
-         << row.quadrature.normalizedNeesMedian << " | "
-         << row.manifold.normalizedNeesMedian << " | "
-         << row.tangent.normalizedNeesMedian << " |\n";
-  }
+  runner.report();
   return 0;
 }

--- a/src/AppUtils.h
+++ b/src/AppUtils.h
@@ -9,16 +9,17 @@
 
 #pragma once
 
-#include "Dataset.h"
-
 #include <algorithm>
-#include <cstdlib>
 #include <filesystem>
+#include <functional>
 #include <iostream>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "Dataset.h"
 
 namespace gtsam {
 
@@ -28,13 +29,50 @@ namespace gtsam {
 struct AppCliOptions {
   std::string dataDirectory = "../data/euroc/";
   std::optional<std::string> datasetName;
-  size_t maxIntervals = 0;
 };
+
+/**
+ * Parsed dataset CLI options plus application-specific trailing arguments.
+ */
+struct ParsedAppCliOptions {
+  AppCliOptions options;
+  std::vector<std::string> remainingArgs;
+};
+
+/**
+ * Resolved datasets plus any application-specific trailing arguments.
+ */
+struct ResolvedDatasetCli {
+  AppCliOptions options;
+  std::vector<std::pair<std::string, std::string>> datasets;
+  std::vector<std::string> remainingArgs;
+};
+
+/// Dataset filter predicate type.
+using DatasetFilter = std::function<bool(const std::string&)>;
+
+/// Predefined dataset filters shared by dataset-driven apps.
+namespace DatasetFilters {
+
+/// Filter for Machine Hall datasets (MH-series).
+inline bool machineHall(const std::string& name) {
+  return name.find("MH") == 0;
+}
+
+/// Filter for Vicon Room datasets (V-series).
+inline bool viconRoom(const std::string& name) { return name.find("V") == 0; }
+
+/// Filter that accepts all datasets.
+inline bool all(const std::string&) { return true; }
+
+}  // namespace DatasetFilters
 
 /**
  * Default interval set used by the quadrature analysis apps.
  */
-inline std::vector<double> defaultQuadratureIntervals() { return {0.2, 0.5, 1.0}; }
+inline std::vector<double> defaultQuadratureIntervals() {
+  return {0.2, 0.5, 1.0};
+}
 
 /**
  * Print common usage help for dataset-driven analysis apps.
@@ -42,10 +80,11 @@ inline std::vector<double> defaultQuadratureIntervals() { return {0.2, 0.5, 1.0}
  */
 inline void printDatasetAppUsage(const char* programName) {
   std::cout << "Usage: " << programName
-            << " [--data-dir <path>] [--dataset <name>] [--max-intervals <count>]\n";
-  std::cout << "  --data-dir <path>       Dataset directory (default: ../data/euroc/)\n";
-  std::cout << "  --dataset <name>        Restrict to one dataset (e.g. MH01 or euroc_MH01.csv)\n";
-  std::cout << "  --max-intervals <count> Restrict to first N default intervals\n";
+            << " [--data-dir <path>] [--dataset <name>]\n";
+  std::cout << "  --data-dir <path>       Dataset directory (default: "
+               "../data/euroc/)\n";
+  std::cout << "  --dataset <name>        Restrict to one dataset (e.g. MH01 "
+               "or euroc_MH01.csv)\n";
 }
 
 /**
@@ -54,7 +93,8 @@ inline void printDatasetAppUsage(const char* programName) {
  * @return Normalized dataset identifier
  */
 inline std::string normalizeDatasetName(const std::string& datasetArgument) {
-  std::string normalized = std::filesystem::path(datasetArgument).stem().string();
+  std::string normalized =
+      std::filesystem::path(datasetArgument).stem().string();
   if (normalized.rfind("euroc_", 0) == 0) {
     normalized = normalized.substr(6);
   }
@@ -62,47 +102,91 @@ inline std::string normalizeDatasetName(const std::string& datasetArgument) {
 }
 
 /**
- * Parse common dataset-analysis CLI flags.
- * @param argc Command-line argc
- * @param argv Command-line argv
- * @return Parsed options
+ * Check whether an argument requests help.
+ * @param argument Command-line token
+ * @return True when the token is --help or -h
  */
-inline AppCliOptions parseDatasetAppCliOptions(int argc, char* argv[]) {
-  AppCliOptions options;
-  for (int index = 1; index < argc; ++index) {
-    const std::string argument = argv[index];
-    if (argument == "--help" || argument == "-h") {
-      printDatasetAppUsage(argv[0]);
-      std::exit(0);
-    }
+inline bool isHelpArgument(const std::string& argument) {
+  return argument == "--help" || argument == "-h";
+}
+
+/**
+ * Parse shared dataset-analysis CLI flags and preserve trailing app-specific
+ * arguments.
+ * @param arguments Command-line arguments excluding argv[0]
+ * @return Parsed dataset options plus unconsumed arguments
+ */
+inline ParsedAppCliOptions parseDatasetAppCliOptions(
+    const std::vector<std::string>& arguments) {
+  ParsedAppCliOptions parsedOptions;
+  for (size_t index = 0; index < arguments.size(); ++index) {
+    const std::string& argument = arguments[index];
     if (argument == "--data-dir") {
-      if (index + 1 >= argc) {
+      if (index + 1 >= arguments.size()) {
         throw std::runtime_error("Missing value for --data-dir");
       }
-      options.dataDirectory = argv[++index];
+      parsedOptions.options.dataDirectory = arguments[++index];
       continue;
     }
     if (argument == "--dataset") {
-      if (index + 1 >= argc) {
+      if (index + 1 >= arguments.size()) {
         throw std::runtime_error("Missing value for --dataset");
       }
-      options.datasetName = normalizeDatasetName(argv[++index]);
+      parsedOptions.options.datasetName =
+          normalizeDatasetName(arguments[++index]);
       continue;
     }
-    if (argument == "--max-intervals") {
-      if (index + 1 >= argc) {
-        throw std::runtime_error("Missing value for --max-intervals");
-      }
-      const int requestedCount = std::stoi(argv[++index]);
-      if (requestedCount <= 0) {
-        throw std::runtime_error("--max-intervals must be positive.");
-      }
-      options.maxIntervals = static_cast<size_t>(requestedCount);
-      continue;
-    }
-    throw std::runtime_error("Unknown argument: " + argument);
+    parsedOptions.remainingArgs.push_back(argument);
   }
-  return options;
+  return parsedOptions;
+}
+
+/**
+ * Parse shared dataset-analysis CLI flags from argc/argv.
+ * @param argc Command-line argc
+ * @param argv Command-line argv
+ * @return Parsed dataset options plus unconsumed arguments
+ */
+inline ParsedAppCliOptions parseDatasetAppCliOptions(int argc, char* argv[]) {
+  std::vector<std::string> arguments;
+  arguments.reserve(std::max(0, argc - 1));
+  for (int index = 1; index < argc; ++index) {
+    arguments.push_back(argv[index]);
+  }
+  return parseDatasetAppCliOptions(arguments);
+}
+
+/**
+ * Discover datasets matching a filter predicate.
+ * @param dataDirectory Directory that contains EuRoC CSV files
+ * @param filter Predicate that selects dataset names
+ * @return Sorted dataset name/path pairs
+ */
+inline std::vector<std::pair<std::string, std::string>>
+discoverFilteredDatasets(const std::string& dataDirectory,
+                         DatasetFilter filter) {
+  namespace fs = std::filesystem;
+  std::vector<std::pair<std::string, std::string>> datasets;
+
+  if (!fs::exists(dataDirectory)) {
+    std::cerr << "❌ Data directory not found: " << dataDirectory << std::endl;
+    return datasets;
+  }
+
+  for (const auto& entry : fs::directory_iterator(dataDirectory)) {
+    if (entry.is_regular_file() && entry.path().extension() == ".csv") {
+      std::string filename = entry.path().filename().string();
+      if (filename.find("euroc_") == 0) {
+        std::string name = normalizeDatasetName(filename);
+        if (filter(name)) {
+          datasets.push_back({name, entry.path().string()});
+        }
+      }
+    }
+  }
+
+  std::sort(datasets.begin(), datasets.end());
+  return datasets;
 }
 
 /**
@@ -127,6 +211,80 @@ inline std::vector<std::pair<std::string, std::string>> selectDatasets(
 }
 
 /**
+ * Resolve the datasets requested by the shared dataset CLI options.
+ * @param options Parsed dataset CLI options
+ * @param filter Dataset discovery predicate
+ * @return Selected dataset name/path pairs
+ */
+inline std::vector<std::pair<std::string, std::string>> resolveDatasets(
+    const AppCliOptions& options, DatasetFilter filter = DatasetFilters::all) {
+  const auto discoveredDatasets =
+      discoverFilteredDatasets(options.dataDirectory, filter);
+  return selectDatasets(discoveredDatasets, options.datasetName);
+}
+
+/**
+ * Parse shared dataset CLI flags and immediately resolve the matching
+ * datasets.
+ * @param arguments Command-line arguments excluding argv[0]
+ * @param filter Dataset discovery predicate
+ * @return Resolved datasets plus unconsumed arguments
+ */
+inline ResolvedDatasetCli resolveDatasetAppCli(
+    const std::vector<std::string>& arguments,
+    DatasetFilter filter = DatasetFilters::all) {
+  const ParsedAppCliOptions parsedOptions =
+      parseDatasetAppCliOptions(arguments);
+  return {parsedOptions.options, resolveDatasets(parsedOptions.options, filter),
+          parsedOptions.remainingArgs};
+}
+
+/**
+ * Parse shared dataset CLI flags from argc/argv and immediately resolve the
+ * matching datasets.
+ * @param argc Command-line argc
+ * @param argv Command-line argv
+ * @param filter Dataset discovery predicate
+ * @return Resolved datasets plus unconsumed arguments
+ */
+inline ResolvedDatasetCli resolveDatasetAppCli(
+    int argc, char* argv[], DatasetFilter filter = DatasetFilters::all) {
+  const ParsedAppCliOptions parsedOptions =
+      parseDatasetAppCliOptions(argc, argv);
+  return {parsedOptions.options, resolveDatasets(parsedOptions.options, filter),
+          parsedOptions.remainingArgs};
+}
+
+/**
+ * Parse the shared quadrature interval limit argument.
+ * @param arguments Unconsumed application-specific arguments
+ * @return Requested interval limit, or zero when unspecified
+ */
+inline size_t parseMaxIntervalsArgument(
+    const std::vector<std::string>& arguments) {
+  size_t maxIntervals = 0;
+  for (size_t index = 0; index < arguments.size(); ++index) {
+    const std::string& argument = arguments[index];
+    if (isHelpArgument(argument)) {
+      continue;
+    }
+    if (argument == "--max-intervals") {
+      if (index + 1 >= arguments.size()) {
+        throw std::runtime_error("Missing value for --max-intervals");
+      }
+      const int requestedCount = std::stoi(arguments[++index]);
+      if (requestedCount <= 0) {
+        throw std::runtime_error("--max-intervals must be positive.");
+      }
+      maxIntervals = static_cast<size_t>(requestedCount);
+      continue;
+    }
+    throw std::runtime_error("Unknown argument: " + argument);
+  }
+  return maxIntervals;
+}
+
+/**
  * Restrict interval count while preserving the existing order.
  * @param defaultIntervals Full interval list
  * @param maxIntervals Requested limit, or zero for no limit
@@ -137,10 +295,45 @@ inline std::vector<double> selectIntervals(
   if (defaultIntervals.empty()) {
     return {};
   }
-  const size_t intervalCount = (maxIntervals == 0)
-      ? defaultIntervals.size()
-      : std::min(maxIntervals, defaultIntervals.size());
-  return std::vector<double>(defaultIntervals.begin(), defaultIntervals.begin() + intervalCount);
+  const size_t intervalCount =
+      (maxIntervals == 0) ? defaultIntervals.size()
+                          : std::min(maxIntervals, defaultIntervals.size());
+  return std::vector<double>(defaultIntervals.begin(),
+                             defaultIntervals.begin() + intervalCount);
+}
+
+/**
+ * Construct each dataset centrally and invoke a mutable runner for it.
+ * Datasets with fewer than two truth states are skipped.
+ * @tparam Runner Callable type with operator()(const std::string&, const
+ * Dataset&)
+ * @param datasetCli Resolved dataset CLI options
+ * @param runner Mutable per-dataset runner
+ * @return Exit code style status: 0 on success, 1 on empty input or dataset
+ * processing failure
+ */
+template <class Runner>
+inline int runForDatasets(const ResolvedDatasetCli& datasetCli,
+                          Runner& runner) {
+  if (datasetCli.datasets.empty()) {
+    std::cerr << "No datasets found in " << datasetCli.options.dataDirectory
+              << "\n";
+    return 1;
+  }
+
+  try {
+    for (const auto& [datasetName, datasetPath] : datasetCli.datasets) {
+      Dataset dataset(datasetPath);
+      if (dataset.truth.size() < 2) {
+        continue;
+      }
+      runner(datasetName, dataset);
+    }
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << "Error: " << error.what() << "\n";
+    return 1;
+  }
 }
 
 }  // namespace gtsam

--- a/src/NoiseCalibration.h
+++ b/src/NoiseCalibration.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
+#include "AppUtils.h"
 #include "EKFNEESEvaluator.h"
-#include "Dataset.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>
@@ -24,8 +24,6 @@
 #include <vector>
 #include <algorithm>
 #include <map>
-#include <filesystem>
-#include <functional>
 
 namespace gtsam {
 
@@ -56,59 +54,6 @@ inline void computeMetrics(NoiseTrialResult& result) {
     }
     result.meanNees = sum / result.datasetNees.size();
     result.sumDeviations = sumDev;
-}
-
-/// Dataset filter predicate type
-using DatasetFilter = std::function<bool(const std::string&)>;
-
-/// Predefined dataset filters
-namespace DatasetFilters {
-    /// Filter for Machine Hall datasets (MH-series)
-    inline bool machineHall(const std::string& name) {
-        return name.find("MH") == 0;
-    }
-    
-    /// Filter for Vicon Room datasets (V-series)
-    inline bool viconRoom(const std::string& name) {
-        return name.find("V") == 0;
-    }
-    
-    /// Filter that accepts all datasets
-    inline bool all(const std::string&) {
-        return true;
-    }
-}
-
-/// Discover datasets matching a filter predicate
-inline std::vector<std::pair<std::string, std::string>> discoverFilteredDatasets(
-    const std::string& dataDirectory, 
-    DatasetFilter filter) {
-    
-    namespace fs = std::filesystem;
-    std::vector<std::pair<std::string, std::string>> datasets;
-    
-    if (!fs::exists(dataDirectory)) {
-        std::cerr << "❌ Data directory not found: " << dataDirectory << std::endl;
-        return datasets;
-    }
-    
-    for (const auto& entry : fs::directory_iterator(dataDirectory)) {
-        if (entry.is_regular_file() && entry.path().extension() == ".csv") {
-            std::string filename = entry.path().filename().string();
-            if (filename.find("euroc_") == 0) {
-                std::string name = filename.substr(6);
-                name = name.substr(0, name.find(".csv"));
-                
-                // Apply filter
-                if (filter(name)) {
-                    datasets.push_back({name, entry.path().string()});
-                }
-            }
-        }
-    }
-    
-    std::sort(datasets.begin(), datasets.end());
-    return datasets;
 }
 
 /// Run calibration with custom dataset filter and study name

--- a/src/PIMs.h
+++ b/src/PIMs.h
@@ -1,13 +1,39 @@
 #pragma once
 
+#include <gtsam/inference/Symbol.h>
 #include <gtsam/navigation/ImuFactor.h>
 #include <gtsam/navigation/QuadratureImuFactor.h>
 
+#include <algorithm>
+#include <cmath>
 #include <memory>
+#include <optional>
 
 #include "Window.h"
+#include "nees.h"
 
 namespace gtsam {
+
+/**
+ * Reduced per-window metrics shared across the evaluation apps.
+ */
+struct WindowResult {
+  double normalizedNees = 0.0;
+  double rotErrorNorm = 0.0;
+  double rotPredSigma = 0.0;
+  double posErrorNorm = 0.0;
+  double posPredSigma = 0.0;
+  double velErrorNorm = 0.0;
+  double velPredSigma = 0.0;
+};
+
+/**
+ * Optional prior covariance to fold into the preintegrated covariance.
+ */
+struct InitialCovarianceOptions {
+  Matrix9 navCovariance = Matrix9::Zero();
+  Matrix6 biasCovariance = Matrix6::Zero();
+};
 
 /**
  * Build a preintegrated IMU measurement object over one window at the given
@@ -36,6 +62,136 @@ buildPreintegrated<PreintegratedImuMeasurementsQ>(
   window.integrateMeasurements(preintegrated);
   preintegrated.endPreintegration(preintegrated.deltaTij());
   return preintegrated;
+}
+
+/**
+ * Convert a 3x3 covariance block into an RMS sigma proxy.
+ */
+inline double covarianceBlockSigma(const Matrix9& covariance, int blockStart) {
+  return std::sqrt(std::max(
+      0.0, covariance.block<3, 3>(blockStart, blockStart).trace() / 3.0));
+}
+
+/**
+ * Reduce a 9D error/covariance pair into the per-window reporting metrics.
+ */
+inline WindowResult makeWindowResult(const Vector9& error,
+                                     const Matrix9& covariance,
+                                     double normalizedNees) {
+  WindowResult result;
+  result.normalizedNees = normalizedNees;
+  result.rotErrorNorm = error.head<3>().norm();
+  result.rotPredSigma = covarianceBlockSigma(covariance, 0);
+  result.posErrorNorm = error.segment<3>(3).norm();
+  result.posPredSigma = covarianceBlockSigma(covariance, 3);
+  result.velErrorNorm = error.tail<3>().norm();
+  result.velPredSigma = covarianceBlockSigma(covariance, 6);
+  return result;
+}
+
+/**
+ * Evaluate one window for a standard preintegration type.
+ */
+template <class PIMType>
+std::optional<WindowResult> evaluateWindow(
+    const Window& window, const std::shared_ptr<PreintegrationParams>& params,
+    std::optional<InitialCovarianceOptions> initialCovariance = std::nullopt,
+    size_t quadratureOrder = 0) {
+  (void)quadratureOrder;
+  const imuBias::ConstantBias& initialBias = window.initialTruth().bias;
+  auto preintegrated = buildPreintegrated<PIMType>(window, params, initialBias);
+
+  if (initialCovariance) {
+    Matrix96 biasJacobian;
+    preintegrated.biasCorrectedDelta(initialBias, biasJacobian);
+    const Matrix9 totalCovariance =
+        preintegrated.preintMeasCov() + initialCovariance->navCovariance +
+        biasJacobian * initialCovariance->biasCovariance *
+            biasJacobian.transpose();
+    preintegrated.setPreintMeasCov(totalCovariance);
+  }
+
+  ImuFactor2T<PIMType> factor(symbol_shorthand::X(1), symbol_shorthand::X(2),
+                              symbol_shorthand::B(1), preintegrated);
+  const Vector9 error =
+      factor.evaluateError(window.initialTruth().navState,
+                           window.terminalTruth().navState, initialBias);
+  const Matrix9 covariance = preintegrated.preintMeasCov();
+  const auto normalizedNees = normalizedNEES(error, covariance, 9.0);
+  if (!normalizedNees || !std::isfinite(*normalizedNees)) {
+    return std::nullopt;
+  }
+  return makeWindowResult(error, covariance, *normalizedNees);
+}
+
+/**
+ * Convert quadrature preintegration output into the shared 9D residual space.
+ */
+inline Vector9 quadratureDeltaForBias(
+    const Window& window, const std::shared_ptr<PreintegrationParams>& params,
+    size_t quadratureOrder, const imuBias::ConstantBias& bias) {
+  const auto preintegrated =
+      buildPreintegrated<PreintegratedImuMeasurementsQ>(
+          window, params, bias, quadratureOrder);
+
+  Vector9 delta;
+  delta << preintegrated.deltaRij().logmap(Rot3()), preintegrated.deltaPij(),
+      preintegrated.deltaVij();
+  return delta;
+}
+
+/**
+ * Evaluate one window for quadrature preintegration.
+ */
+template <>
+inline std::optional<WindowResult> evaluateWindow<PreintegratedImuMeasurementsQ>(
+    const Window& window, const std::shared_ptr<PreintegrationParams>& params,
+    std::optional<InitialCovarianceOptions> initialCovariance,
+    size_t quadratureOrder) {
+  const imuBias::ConstantBias& initialBias = window.initialTruth().bias;
+  auto preintegrated = buildPreintegrated<PreintegratedImuMeasurementsQ>(
+      window, params, initialBias, quadratureOrder);
+
+  if (initialCovariance) {
+    constexpr double kBiasPerturbation = 1e-5;
+    Matrix96 biasJacobian;
+    const Vector6 biasVector = initialBias.vector();
+    for (int column = 0; column < 6; ++column) {
+      Vector6 plusBias = biasVector;
+      Vector6 minusBias = biasVector;
+      plusBias(column) += kBiasPerturbation;
+      minusBias(column) -= kBiasPerturbation;
+
+      const Vector9 deltaPlus = quadratureDeltaForBias(
+          window, params, quadratureOrder,
+          imuBias::ConstantBias(plusBias.head<3>(), plusBias.tail<3>()));
+      const Vector9 deltaMinus = quadratureDeltaForBias(
+          window, params, quadratureOrder,
+          imuBias::ConstantBias(minusBias.head<3>(), minusBias.tail<3>()));
+      biasJacobian.col(column) =
+          (deltaPlus - deltaMinus) / (2.0 * kBiasPerturbation);
+    }
+
+    preintegrated.setInitialCovariance(
+        initialCovariance->navCovariance +
+        biasJacobian * initialCovariance->biasCovariance *
+            biasJacobian.transpose());
+  }
+
+  ImuFactorT<PreintegratedImuMeasurementsQ> factor(
+      symbol_shorthand::X(1), symbol_shorthand::V(1), symbol_shorthand::X(2),
+      symbol_shorthand::V(2), symbol_shorthand::B(1), preintegrated);
+  const Vector9 error = factor.evaluateError(
+      window.initialTruth().navState.pose(),
+      window.initialTruth().navState.velocity(),
+      window.terminalTruth().navState.pose(),
+      window.terminalTruth().navState.velocity(), initialBias);
+  const Matrix9 covariance = preintegrated.preintMeasCov();
+  const auto normalizedNees = normalizedNEES(error, covariance, 9.0);
+  if (!normalizedNees || !std::isfinite(*normalizedNees)) {
+    return std::nullopt;
+  }
+  return makeWindowResult(error, covariance, *normalizedNees);
 }
 
 }  // namespace gtsam

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,3 +27,4 @@ endfunction()
 
 imufactors_add_local_test(testImuNEES testImuNEES.cpp)
 imufactors_add_local_test(testDatasetSanity testDatasetSanity.cpp)
+imufactors_add_local_test(testAppUtils testAppUtils.cpp)

--- a/tests/testAppUtils.cpp
+++ b/tests/testAppUtils.cpp
@@ -1,0 +1,141 @@
+/* ----------------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+ *
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   testAppUtils.cpp
+ * @brief  Unit tests for dataset CLI and discovery helpers
+ */
+
+#include <CppUnitLite/TestHarness.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "AppUtils.h"
+
+using namespace gtsam;
+
+namespace {
+
+struct ScopedTempDirectory {
+  explicit ScopedTempDirectory(const std::string& directoryName)
+      : path(std::filesystem::current_path() / directoryName) {
+    std::filesystem::remove_all(path);
+    std::filesystem::create_directories(path);
+  }
+
+  ~ScopedTempDirectory() { std::filesystem::remove_all(path); }
+
+  std::filesystem::path path;
+};
+
+void createEmptyFile(const std::filesystem::path& path) {
+  std::ofstream stream(path);
+  stream << "placeholder\n";
+}
+
+struct CountingRunner {
+  size_t callCount = 0;
+
+  void operator()(const std::string&, const Dataset&) { ++callCount; }
+};
+
+struct ThrowingRunner {
+  void operator()(const std::string&, const Dataset&) {
+    throw std::runtime_error("runner failed");
+  }
+};
+
+}  // namespace
+
+/* ************************************************************************* */
+TEST(AppUtils, NormalizeDatasetName) {
+  EXPECT(normalizeDatasetName("MH01") == "MH01");
+  EXPECT(normalizeDatasetName("euroc_MH01.csv") == "MH01");
+  EXPECT(normalizeDatasetName("/tmp/euroc_V202.csv") == "V202");
+}
+
+/* ************************************************************************* */
+TEST(AppUtils, ParseDatasetCliOptionsPreservesRemainingArgs) {
+  const ParsedAppCliOptions parsedOptions = parseDatasetAppCliOptions(
+      {"--dataset", "euroc_MH01.csv", "--data-dir", "/tmp/euroc",
+       "--max-intervals", "2", "--custom-flag"});
+
+  EXPECT(parsedOptions.options.dataDirectory == "/tmp/euroc");
+  EXPECT(parsedOptions.options.datasetName.has_value());
+  EXPECT(parsedOptions.options.datasetName.value() == "MH01");
+  EXPECT(parsedOptions.remainingArgs.size() == 3);
+  EXPECT(parsedOptions.remainingArgs[0] == "--max-intervals");
+  EXPECT(parsedOptions.remainingArgs[1] == "2");
+  EXPECT(parsedOptions.remainingArgs[2] == "--custom-flag");
+}
+
+/* ************************************************************************* */
+TEST(AppUtils, ResolveDatasetCliFiltersAndSortsDatasets) {
+  const ScopedTempDirectory tempDirectory("app_utils_test_tmp");
+  createEmptyFile(tempDirectory.path / "euroc_V202.csv");
+  createEmptyFile(tempDirectory.path / "euroc_MH01.csv");
+  createEmptyFile(tempDirectory.path / "notes.txt");
+
+  const ResolvedDatasetCli allDatasets =
+      resolveDatasetAppCli({"--data-dir", tempDirectory.path.string()});
+  EXPECT(allDatasets.datasets.size() == 2);
+  EXPECT(allDatasets.datasets[0].first == "MH01");
+  EXPECT(allDatasets.datasets[1].first == "V202");
+
+  const ResolvedDatasetCli filteredDataset =
+      resolveDatasetAppCli({"--data-dir", tempDirectory.path.string(),
+                            "--dataset", "euroc_V202.csv"});
+  EXPECT(filteredDataset.datasets.size() == 1);
+  EXPECT(filteredDataset.datasets[0].first == "V202");
+  EXPECT(filteredDataset.remainingArgs.empty());
+}
+
+/* ************************************************************************* */
+TEST(AppUtils, ParseMaxIntervalsArgument) {
+  EXPECT(parseMaxIntervalsArgument({}) == 0);
+  EXPECT(parseMaxIntervalsArgument({"--max-intervals", "2"}) == 2);
+}
+
+/* ************************************************************************* */
+TEST(AppUtils, RunForDatasetsHandlesEmptyAndExceptions) {
+  std::ostringstream capturedErrors;
+  std::streambuf* const originalErrorBuffer = std::cerr.rdbuf();
+  std::cerr.rdbuf(capturedErrors.rdbuf());
+
+  const ResolvedDatasetCli emptyCli{{"/tmp/missing", std::nullopt}, {}, {}};
+  CountingRunner countingRunner;
+  const int emptyStatus = runForDatasets(emptyCli, countingRunner);
+  EXPECT(emptyStatus == 1);
+  EXPECT(countingRunner.callCount == 0);
+  EXPECT(capturedErrors.str().find("No datasets found in /tmp/missing") !=
+         std::string::npos);
+
+  capturedErrors.str("");
+  capturedErrors.clear();
+
+  const ResolvedDatasetCli datasetCli = resolveDatasetAppCli(
+      {"--data-dir", "../data/euroc", "--dataset", "MH01"});
+  ThrowingRunner throwingRunner;
+  const int exceptionStatus = runForDatasets(datasetCli, throwingRunner);
+  EXPECT(exceptionStatus == 1);
+  EXPECT(capturedErrors.str().find("Error: runner failed") !=
+         std::string::npos);
+
+  std::cerr.rdbuf(originalErrorBuffer);
+}
+
+/* ************************************************************************* */
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}

--- a/tests/testImuNEES.cpp
+++ b/tests/testImuNEES.cpp
@@ -20,9 +20,50 @@
 #include <fstream>
 
 #include "NEESEvaluator.h"
+#include "PIMs.h"
+
+#include <gtsam/navigation/ManifoldPreintegration.h>
+#include <gtsam/navigation/TangentPreintegration.h>
 
 using namespace std;
 using namespace gtsam;
+
+namespace {
+
+using PIMQuadrature = PreintegratedImuMeasurementsQ;
+using PIMTangent = PreintegratedImuMeasurementsT<TangentPreintegration>;
+using PIMManifold = PreintegratedImuMeasurementsT<ManifoldPreintegration>;
+
+shared_ptr<PreintegrationParams> createPreintegrationParams() {
+  constexpr double kAlpha = 3.0;
+  constexpr double kSigmaGyro = kAlpha * 1.6968e-4;
+  constexpr double kSigmaAcc = kAlpha * 2.0000e-3;
+
+  auto params = PreintegrationParams::MakeSharedU(9.81);
+  params->accelerometerCovariance = I_3x3 * kSigmaAcc * kSigmaAcc;
+  params->gyroscopeCovariance = I_3x3 * kSigmaGyro * kSigmaGyro;
+  params->integrationCovariance = I_3x3 * 1e-8;
+  return params;
+}
+
+bool isFinite(const WindowResult& result) {
+  return std::isfinite(result.normalizedNees) &&
+         std::isfinite(result.rotErrorNorm) &&
+         std::isfinite(result.rotPredSigma) &&
+         std::isfinite(result.posErrorNorm) &&
+         std::isfinite(result.posPredSigma) &&
+         std::isfinite(result.velErrorNorm) &&
+         std::isfinite(result.velPredSigma);
+}
+
+bool hasNonDecreasingPredictedSigma(const WindowResult& baseline,
+                                    const WindowResult& withPrior) {
+  return withPrior.rotPredSigma >= baseline.rotPredSigma &&
+         withPrior.posPredSigma >= baseline.posPredSigma &&
+         withPrior.velPredSigma >= baseline.velPredSigma;
+}
+
+}  // namespace
 
 /**
  * This test suite uses the EuRoC MAV dataset, published in:
@@ -48,6 +89,54 @@ TEST(ImuFactor, NEES) {
       results.printStatistics();
       EXPECT(!results.neesValues.empty());
     }
+  } catch (const exception& e) {
+    FAIL(e.what());
+  }
+}
+
+/* ************************************************************************* */
+TEST(ImuFactor, WindowEvaluation) {
+  try {
+    const string dataPath = "../data/euroc/euroc_V202.csv";
+    const Dataset dataset(dataPath);
+    const size_t stepsPerWindow = dataset.stepsForInterval(0.2);
+    const vector<Window> windows = dataset.completeWindows(stepsPerWindow);
+    EXPECT(!windows.empty());
+    if (windows.empty()) return;
+
+    const Window& window = windows.front();
+    const auto params = createPreintegrationParams();
+    const InitialCovarianceOptions initialCovariance{
+        Matrix9::Identity() * 5e-6, Matrix6::Identity() * 1e-1};
+
+    const auto manifold = evaluateWindow<PIMManifold>(window, params);
+    const auto tangent = evaluateWindow<PIMTangent>(window, params);
+    const auto quadrature = evaluateWindow<PIMQuadrature>(window, params,
+                                                          std::nullopt, 3);
+    const auto manifoldWithPrior =
+        evaluateWindow<PIMManifold>(window, params, initialCovariance);
+    const auto quadratureWithPrior =
+        evaluateWindow<PIMQuadrature>(window, params, initialCovariance, 3);
+
+    EXPECT(manifold.has_value());
+    EXPECT(tangent.has_value());
+    EXPECT(quadrature.has_value());
+    EXPECT(manifoldWithPrior.has_value());
+    EXPECT(quadratureWithPrior.has_value());
+
+    if (!manifold || !tangent || !quadrature || !manifoldWithPrior ||
+        !quadratureWithPrior) {
+      return;
+    }
+
+    EXPECT(isFinite(*manifold));
+    EXPECT(isFinite(*tangent));
+    EXPECT(isFinite(*quadrature));
+    EXPECT(isFinite(*manifoldWithPrior));
+    EXPECT(isFinite(*quadratureWithPrior));
+
+    EXPECT(hasNonDecreasingPredictedSigma(*manifold, *manifoldWithPrior));
+    EXPECT(hasNonDecreasingPredictedSigma(*quadrature, *quadratureWithPrior));
   } catch (const exception& e) {
     FAIL(e.what());
   }


### PR DESCRIPTION
## Summary
- add reusable dataset-run helpers in `AppUtils`, plus `WindowResult` support in `PIMs`
- refactor the evaluation apps to share the new flow and standardize their reporting/output formatting
- add focused coverage for the new dataset utilities and IMU NEES window-result behavior

## Why
The evaluation binaries had overlapping dataset iteration/reporting logic and inconsistent result formatting. This branch consolidates the shared execution path, makes windowed IMU NEES reporting explicit, and keeps the apps aligned.

## Impact
The evaluation tools now use a common dataset-running/reporting structure, the IMU diagnostics expose a dedicated window result type, and the new behavior is covered by local tests.

## Validation
- `make -j6 testImuNEES.run testAppUtils.run`