### PR TITLE
[codex] Add Dash summary viewer and comparison tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,17 +245,19 @@ python -m viewer.app --results-root build/results --host 127.0.0.1 --port 8050
 ### What The MVP Shows
 
 - a discovered run catalog from one results root
+- a refresh button to rescan that results root without restarting Dash
 - run metadata from `run_metadata.csv`
 - dataset membership from `datasets.csv`
 - `window_summaries.csv` when populated
+- a pivoted window-summary comparison table that lines methods up side-by-side
 - `calibration_summaries.csv` when populated
+- multi-run summary comparison across the active run plus additional selected runs
 
 The app treats zero-byte, missing, or header-only CSVs as intentional empty
 states where possible, so incomplete result packages do not crash the UI.
 
 ### Current MVP Limitations
 
-- single-run inspection only
 - summary tables only
 - no `window_metrics.csv` detail tables yet
 - no trajectory views from `trajectory_samples.csv` yet
@@ -266,7 +268,6 @@ states where possible, so incomplete result packages do not crash the UI.
 
 Planned next steps for the Python viewer:
 
-- multi-run summary comparison across selected runs
 - detailed `window_metrics.csv` tables with additional filtering
 - trajectory tables with careful sampling and downsampling controls
 - Plotly charts for summaries and trajectory-derived metrics

--- a/README.md
+++ b/README.md
@@ -207,3 +207,67 @@ Use `evalReducedNeesWithPriorCovariance` for the normalized-NEES comparison
 with initial state/bias covariance folded into the analysis, and
 `evalQuadratureImuFactorDiagnostics` for the fuller NEES/error export over the
 same intervals and datasets.
+
+## Python Summary Viewer
+
+The repository now includes a small Dash-based summary viewer for the canonical
+CSV packages. The MVP is intentionally read-only and summary-focused.
+
+### One-time setup
+
+Use the `py312` conda environment for all Python tooling in this repository.
+
+```bash
+conda activate py312
+pip install dash
+```
+
+### Launch
+
+From the repository root:
+
+```bash
+python -m viewer.app
+```
+
+By default the viewer scans `build/results`. Override that with:
+
+```bash
+python -m viewer.app --results-root build/ui_probe
+```
+
+Optional flags:
+
+```bash
+python -m viewer.app --results-root build/results --host 127.0.0.1 --port 8050
+```
+
+### What The MVP Shows
+
+- a discovered run catalog from one results root
+- run metadata from `run_metadata.csv`
+- dataset membership from `datasets.csv`
+- `window_summaries.csv` when populated
+- `calibration_summaries.csv` when populated
+
+The app treats zero-byte, missing, or header-only CSVs as intentional empty
+states where possible, so incomplete result packages do not crash the UI.
+
+### Current MVP Limitations
+
+- single-run inspection only
+- summary tables only
+- no `window_metrics.csv` detail tables yet
+- no trajectory views from `trajectory_samples.csv` yet
+- no graphs yet
+- no write-back or package repair behavior
+
+## Viewer Roadmap
+
+Planned next steps for the Python viewer:
+
+- multi-run summary comparison across selected runs
+- detailed `window_metrics.csv` tables with additional filtering
+- trajectory tables with careful sampling and downsampling controls
+- Plotly charts for summaries and trajectory-derived metrics
+- richer validation and diagnostics for incomplete or partially written runs

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,1 @@
+"""Python support package for imuFactors tooling."""

--- a/python/tests/test_viewer_summary.py
+++ b/python/tests/test_viewer_summary.py
@@ -1,0 +1,180 @@
+"""Smoke tests for summary-viewer discovery and loading."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from python.viewer.app import create_dash_app
+from python.viewer.discovery import discover_runs
+from python.viewer.loading import load_run_data
+
+
+def write_text(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def make_run(root: Path, app_name: str, run_id: str) -> Path:
+    run_dir = root / app_name / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+class ViewerSummaryTests(unittest.TestCase):
+    def test_discover_runs_complete_and_header_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = make_run(root, "evalFoo", "20260417T000000000Z")
+            write_text(
+                run_dir / "run_metadata.csv",
+                "run_id,app_name,timestamp_utc,cli_args,output_root,repo_version\n"
+                "20260417T000000000Z,evalFoo,2026-04-17T00:00:00.000Z,./evalFoo,./results,\n",
+            )
+            write_text(
+                run_dir / "datasets.csv",
+                "run_id,app_name,dataset,source_path,dataset_group\n"
+                "20260417T000000000Z,evalFoo,MH01,../data/euroc/euroc_MH01.csv,machine_hall\n",
+            )
+            write_text(
+                run_dir / "window_summaries.csv",
+                "run_id,app_name,dataset,method,config_label,interval_seconds,samples_per_window,"
+                "quadrature_nodes,sample_count,normalized_nees_mean,normalized_nees_median,"
+                "normalized_nees_p95,normalized_nees_variance,rot_error_median,rot_pred_sigma_median,"
+                "pos_error_median,pos_pred_sigma_median,vel_error_median,vel_pred_sigma_median\n",
+            )
+            write_text(
+                run_dir / "calibration_summaries.csv",
+                "run_id,app_name,study_name,result_label,alpha_gyro,alpha_acc,mean_nees,sum_deviations\n",
+            )
+
+            catalog = discover_runs(root)
+            self.assertEqual(len(catalog), 1)
+            self.assertEqual(catalog[0].status, "ready")
+            self.assertEqual(catalog[0].dataset_group_label, "machine_hall")
+
+    def test_discover_runs_partial_for_zero_byte_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = make_run(root, "evalFoo", "20260417T000000001Z")
+            write_text(
+                run_dir / "run_metadata.csv",
+                "run_id,app_name,timestamp_utc,cli_args,output_root,repo_version\n"
+                "20260417T000000001Z,evalFoo,2026-04-17T00:00:01.000Z,./evalFoo,./results,\n",
+            )
+            (run_dir / "window_summaries.csv").touch()
+
+            catalog = discover_runs(root)
+            self.assertEqual(len(catalog), 1)
+            self.assertEqual(catalog[0].status, "partial")
+
+    def test_discover_runs_fallback_to_path_when_metadata_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = make_run(root, "evalFallback", "20260417T000000002Z")
+            write_text(
+                run_dir / "window_summaries.csv",
+                "run_id,app_name,dataset,method,config_label,interval_seconds,samples_per_window,"
+                "quadrature_nodes,sample_count,normalized_nees_mean,normalized_nees_median,"
+                "normalized_nees_p95,normalized_nees_variance,rot_error_median,rot_pred_sigma_median,"
+                "pos_error_median,pos_pred_sigma_median,vel_error_median,vel_pred_sigma_median\n"
+                "20260417T000000002Z,evalFallback,MH01,quadrature,default,0.2,40,6,720,1.0,0.5,1.5,0.2,0.1,0.1,0.2,0.2,0.3,0.3\n",
+            )
+
+            catalog = discover_runs(root)
+            self.assertEqual(len(catalog), 1)
+            self.assertEqual(catalog[0].app_name, "evalFallback")
+            self.assertEqual(catalog[0].run_id, "20260417T000000002Z")
+            self.assertEqual(catalog[0].status, "partial")
+
+    def test_load_run_data_window_summary_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = make_run(root, "evalWindow", "20260417T000000003Z")
+            write_text(
+                run_dir / "run_metadata.csv",
+                "run_id,app_name,timestamp_utc,cli_args,output_root,repo_version\n"
+                "20260417T000000003Z,evalWindow,2026-04-17T00:00:03.000Z,./evalWindow,./results,\n",
+            )
+            write_text(
+                run_dir / "window_summaries.csv",
+                "run_id,app_name,dataset,method,config_label,interval_seconds,samples_per_window,"
+                "quadrature_nodes,sample_count,normalized_nees_mean,normalized_nees_median,"
+                "normalized_nees_p95,normalized_nees_variance,rot_error_median,rot_pred_sigma_median,"
+                "pos_error_median,pos_pred_sigma_median,vel_error_median,vel_pred_sigma_median\n"
+                "20260417T000000003Z,evalWindow,MH01,quadrature,default,0.2,40,6,720,1.0,0.5,1.5,0.2,0.1,0.1,0.2,0.2,0.3,0.3\n",
+            )
+            entry = discover_runs(root)[0]
+            run_data = load_run_data(entry)
+            self.assertEqual(len(run_data.window_summaries), 1)
+            self.assertTrue(run_data.calibration_summaries.empty)
+
+    def test_load_run_data_calibration_summary_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = make_run(root, "evalCalibration", "20260417T000000004Z")
+            write_text(
+                run_dir / "run_metadata.csv",
+                "run_id,app_name,timestamp_utc,cli_args,output_root,repo_version\n"
+                "20260417T000000004Z,evalCalibration,2026-04-17T00:00:04.000Z,./evalCalibration,./results,\n",
+            )
+            write_text(
+                run_dir / "calibration_summaries.csv",
+                "run_id,app_name,study_name,result_label,alpha_gyro,alpha_acc,mean_nees,sum_deviations\n"
+                "20260417T000000004Z,evalCalibration,all_coarse,best,1.0,2.0,0.8,0.2\n",
+            )
+            entry = discover_runs(root)[0]
+            run_data = load_run_data(entry)
+            self.assertTrue(run_data.window_summaries.empty)
+            self.assertEqual(len(run_data.calibration_summaries), 1)
+
+    def test_load_run_data_no_populated_summaries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = make_run(root, "evalEmpty", "20260417T000000005Z")
+            write_text(
+                run_dir / "run_metadata.csv",
+                "run_id,app_name,timestamp_utc,cli_args,output_root,repo_version\n"
+                "20260417T000000005Z,evalEmpty,2026-04-17T00:00:05.000Z,./evalEmpty,./results,\n",
+            )
+            write_text(
+                run_dir / "window_summaries.csv",
+                "run_id,app_name,dataset,method,config_label,interval_seconds,samples_per_window,"
+                "quadrature_nodes,sample_count,normalized_nees_mean,normalized_nees_median,"
+                "normalized_nees_p95,normalized_nees_variance,rot_error_median,rot_pred_sigma_median,"
+                "pos_error_median,pos_pred_sigma_median,vel_error_median,vel_pred_sigma_median\n",
+            )
+            write_text(
+                run_dir / "calibration_summaries.csv",
+                "run_id,app_name,study_name,result_label,alpha_gyro,alpha_acc,mean_nees,sum_deviations\n",
+            )
+            entry = discover_runs(root)[0]
+            run_data = load_run_data(entry)
+            self.assertTrue(run_data.window_summaries.empty)
+            self.assertTrue(run_data.calibration_summaries.empty)
+
+    def test_create_dash_app_uses_discovered_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir = make_run(root, "evalDash", "20260417T000000006Z")
+            write_text(
+                run_dir / "run_metadata.csv",
+                "run_id,app_name,timestamp_utc,cli_args,output_root,repo_version\n"
+                "20260417T000000006Z,evalDash,2026-04-17T00:00:06.000Z,./evalDash,./results,\n",
+            )
+            write_text(
+                run_dir / "window_summaries.csv",
+                "run_id,app_name,dataset,method,config_label,interval_seconds,samples_per_window,"
+                "quadrature_nodes,sample_count,normalized_nees_mean,normalized_nees_median,"
+                "normalized_nees_p95,normalized_nees_variance,rot_error_median,rot_pred_sigma_median,"
+                "pos_error_median,pos_pred_sigma_median,vel_error_median,vel_pred_sigma_median\n"
+                "20260417T000000006Z,evalDash,MH01,quadrature,default,0.2,40,6,720,1.0,0.5,1.5,0.2,0.1,0.1,0.2,0.2,0.3,0.3\n",
+            )
+
+            app = create_dash_app(root)
+            self.assertEqual(app.title, "imuFactors Summary Viewer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_viewer_summary.py
+++ b/python/tests/test_viewer_summary.py
@@ -238,6 +238,7 @@ class ViewerSummaryTests(unittest.TestCase):
                 "sample_count": 400,
                 "method": "quadrature",
                 "normalized_nees_mean": 0.0240659,
+                "normalized_nees_median": 0.0187926,
                 "rot_error_median": 0.0011,
                 "pos_error_median": 0.0022,
                 "vel_error_median": 0.0033,
@@ -250,6 +251,7 @@ class ViewerSummaryTests(unittest.TestCase):
                 "sample_count": 400,
                 "method": "manifold",
                 "normalized_nees_mean": 0.0189061,
+                "normalized_nees_median": 0.0151347,
                 "rot_error_median": 0.0010,
                 "pos_error_median": 0.0021,
                 "vel_error_median": 0.0031,
@@ -262,19 +264,30 @@ class ViewerSummaryTests(unittest.TestCase):
                 "sample_count": 400,
                 "method": "tangent",
                 "normalized_nees_mean": 0.0189061,
+                "normalized_nees_median": 0.0151347,
                 "rot_error_median": 0.0010,
                 "pos_error_median": 0.0021,
                 "vel_error_median": 0.0031,
             },
         ]
 
-        columns, comparison_rows = _build_window_method_comparison(rows, "core")
+        columns, comparison_rows, style_rules = _build_window_method_comparison(rows, "core")
         self.assertEqual(comparison_rows[0]["dataset"], "V102")
         self.assertIn("normalized_nees_mean__quadrature", comparison_rows[0])
         self.assertIn("normalized_nees_mean__manifold", comparison_rows[0])
         self.assertIn("normalized_nees_mean__tangent", comparison_rows[0])
         self.assertEqual(columns[0]["name"], ["Dataset", ""])
         self.assertEqual(columns[5]["name"], ["Normalized NEES Mean", "Quadrature"])
+        self.assertEqual(comparison_rows[0]["normalized_nees_mean__quadrature"], "0.02407")
+        self.assertEqual(comparison_rows[0]["rot_error_median__manifold"], "0.001")
+        self.assertIn(
+            {"if": {"row_index": 0, "column_id": "rot_error_median__manifold"}, "fontWeight": "700"},
+            style_rules,
+        )
+        self.assertIn(
+            {"if": {"row_index": 0, "column_id": "normalized_nees_mean__quadrature"}, "fontWeight": "700"},
+            style_rules,
+        )
 
 
 if __name__ == "__main__":

--- a/python/tests/test_viewer_summary.py
+++ b/python/tests/test_viewer_summary.py
@@ -6,7 +6,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from python.viewer.app import create_dash_app
+from python.viewer.app import (
+    _build_window_method_comparison,
+    _comparison_rows,
+    _resolve_compare_paths,
+    create_dash_app,
+)
 from python.viewer.discovery import discover_runs
 from python.viewer.loading import load_run_data
 
@@ -174,6 +179,102 @@ class ViewerSummaryTests(unittest.TestCase):
 
             app = create_dash_app(root)
             self.assertEqual(app.title, "imuFactors Summary Viewer")
+
+    def test_resolve_compare_paths_includes_selected_once(self) -> None:
+        resolved = _resolve_compare_paths("run-a", ["run-b", "run-a", "run-c"])
+        self.assertEqual(resolved, ["run-a", "run-b", "run-c"])
+
+    def test_comparison_rows_merge_multiple_runs(self) -> None:
+        payloads = [
+            {
+                "entry": {
+                    "app_name": "evalA",
+                    "run_id": "run-a",
+                    "path": "/tmp/evalA/run-a",
+                    "status": "ready",
+                    "timestamp_utc": "2026-04-17T00:00:00.000Z",
+                },
+                "window_rows": [
+                    {
+                        "dataset": "MH01",
+                        "method": "quadrature",
+                        "config_label": "default",
+                        "interval_seconds": 0.2,
+                    }
+                ],
+            },
+            {
+                "entry": {
+                    "app_name": "evalB",
+                    "run_id": "run-b",
+                    "path": "/tmp/evalB/run-b",
+                    "status": "partial",
+                    "timestamp_utc": "2026-04-17T00:00:01.000Z",
+                },
+                "window_rows": [
+                    {
+                        "dataset": "MH02",
+                        "method": "manifold",
+                        "config_label": "best",
+                        "interval_seconds": 0.5,
+                    }
+                ],
+            },
+        ]
+
+        columns, rows = _comparison_rows(payloads, "window_rows")
+        self.assertEqual(columns[:5], ["run_label", "app_name", "run_id", "timestamp_utc", "status"])
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["run_label"], "evalA | run-a")
+        self.assertEqual(rows[1]["dataset"], "MH02")
+
+    def test_build_window_method_comparison_pivots_methods_side_by_side(self) -> None:
+        rows = [
+            {
+                "dataset": "V102",
+                "interval_seconds": 0.2,
+                "config_label": "default",
+                "samples_per_window": 40,
+                "sample_count": 400,
+                "method": "quadrature",
+                "normalized_nees_mean": 0.0240659,
+                "rot_error_median": 0.0011,
+                "pos_error_median": 0.0022,
+                "vel_error_median": 0.0033,
+            },
+            {
+                "dataset": "V102",
+                "interval_seconds": 0.2,
+                "config_label": "default",
+                "samples_per_window": 40,
+                "sample_count": 400,
+                "method": "manifold",
+                "normalized_nees_mean": 0.0189061,
+                "rot_error_median": 0.0010,
+                "pos_error_median": 0.0021,
+                "vel_error_median": 0.0031,
+            },
+            {
+                "dataset": "V102",
+                "interval_seconds": 0.2,
+                "config_label": "default",
+                "samples_per_window": 40,
+                "sample_count": 400,
+                "method": "tangent",
+                "normalized_nees_mean": 0.0189061,
+                "rot_error_median": 0.0010,
+                "pos_error_median": 0.0021,
+                "vel_error_median": 0.0031,
+            },
+        ]
+
+        columns, comparison_rows = _build_window_method_comparison(rows, "core")
+        self.assertEqual(comparison_rows[0]["dataset"], "V102")
+        self.assertIn("normalized_nees_mean__quadrature", comparison_rows[0])
+        self.assertIn("normalized_nees_mean__manifold", comparison_rows[0])
+        self.assertIn("normalized_nees_mean__tangent", comparison_rows[0])
+        self.assertEqual(columns[0]["name"], ["Dataset", ""])
+        self.assertEqual(columns[5]["name"], ["Normalized NEES Mean", "Quadrature"])
 
 
 if __name__ == "__main__":

--- a/python/viewer/__init__.py
+++ b/python/viewer/__init__.py
@@ -1,0 +1,5 @@
+"""Dash summary viewer for canonical imuFactors result packages."""
+
+from .app import create_dash_app, main
+
+__all__ = ["create_dash_app", "main"]

--- a/python/viewer/app.py
+++ b/python/viewer/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 from pathlib import Path
 from typing import Any
 
@@ -172,6 +173,12 @@ WINDOW_COMPARISON_INDEX_COLUMNS = [
     ("sample_count", "Sample Count"),
 ]
 
+WINDOW_METRICS_CLOSE_TO_ONE = {
+    "normalized_nees_mean",
+    "normalized_nees_median",
+    "normalized_nees_p95",
+}
+
 
 def _method_sort_key(method: str) -> tuple[int, str]:
     preferred_order = {
@@ -188,15 +195,40 @@ def _pretty_method_name(method: str) -> str:
     return method.replace("_", " ").title()
 
 
+def _format_significant_digits(value: Any, digits: int = 4) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if pd.isna(value):
+        return ""
+    if isinstance(value, (int, float)):
+        return format(float(value), f".{digits}g")
+    return value
+
+
+def _metric_score(metric: str, value: Any) -> float | None:
+    if value is None or pd.isna(value):
+        return None
+    numeric_value = float(value)
+    if metric in WINDOW_METRICS_CLOSE_TO_ONE:
+        return abs(numeric_value - 1.0)
+    return numeric_value
+
+
+def _is_same_score(left: float, right: float) -> bool:
+    return math.isclose(left, right, rel_tol=1e-9, abs_tol=1e-12)
+
+
 def _build_window_method_comparison(
     rows: list[dict[str, Any]], metric_group: str
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     if not rows:
-        return [], []
+        return [], [], []
 
     frame = pd.DataFrame(rows)
     if frame.empty or "method" not in frame.columns:
-        return [], []
+        return [], [], []
 
     metrics = [
         metric
@@ -204,20 +236,20 @@ def _build_window_method_comparison(
         if metric in frame.columns
     ]
     if not metrics:
-        return [], []
+        return [], [], []
 
     index_columns = [column for column, _label in WINDOW_COMPARISON_INDEX_COLUMNS if column in frame.columns]
     if not index_columns:
-        return [], []
+        return [], [], []
 
     method_names = sorted(frame["method"].dropna().unique().tolist(), key=_method_sort_key)
     if not method_names:
-        return [], []
+        return [], [], []
 
     grouped = frame[index_columns + ["method", *metrics]].copy()
     pivot = grouped.pivot_table(index=index_columns, columns="method", values=metrics, aggfunc="first")
     if pivot.empty:
-        return [], []
+        return [], [], []
 
     columns: list[dict[str, Any]] = []
     for column, label in WINDOW_COMPARISON_INDEX_COLUMNS:
@@ -232,23 +264,54 @@ def _build_window_method_comparison(
                 {
                     "name": [metric_label, _pretty_method_name(method_name)],
                     "id": column_id,
-                    "type": "numeric",
                 }
             )
 
     comparison_rows: list[dict[str, Any]] = []
+    style_rules: list[dict[str, Any]] = []
     for index_values, series in pivot.iterrows():
         if not isinstance(index_values, tuple):
             index_values = (index_values,)
         row: dict[str, Any] = {
             index_columns[index]: index_values[index] for index in range(len(index_columns))
         }
+        row_index = len(comparison_rows)
         for metric in metrics:
+            metric_scores: list[tuple[str, float]] = []
             for method_name in method_names:
-                row[f"{metric}__{method_name}"] = series.get((metric, method_name))
+                column_id = f"{metric}__{method_name}"
+                value = series.get((metric, method_name))
+                row[column_id] = _format_significant_digits(value)
+                score = _metric_score(metric, value)
+                if score is not None:
+                    metric_scores.append((column_id, score))
+
+            if metric_scores:
+                best_score = min(score for _column_id, score in metric_scores)
+                second_best_score = next(
+                    (
+                        score
+                        for score in sorted(score for _column_id, score in metric_scores)
+                        if not _is_same_score(score, best_score)
+                    ),
+                    None,
+                )
+                for column_id, score in metric_scores:
+                    if _is_same_score(score, best_score):
+                        style_rules.append(
+                            {"if": {"row_index": row_index, "column_id": column_id}, "fontWeight": "700"}
+                        )
+                    elif second_best_score is not None and _is_same_score(score, second_best_score):
+                        style_rules.append(
+                            {
+                                "if": {"row_index": row_index, "column_id": column_id},
+                                "textDecoration": "underline",
+                                "textDecorationThickness": "2px",
+                            }
+                        )
         comparison_rows.append(row)
 
-    return columns, comparison_rows
+    return columns, comparison_rows, style_rules
 
 
 def _resolve_compare_paths(selected_path: str | None, compare_paths: list[str] | None) -> list[str]:
@@ -445,6 +508,7 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
         Output("window-comparison-message", "children"),
         Output("window-method-compare-table", "columns"),
         Output("window-method-compare-table", "data"),
+        Output("window-method-compare-table", "style_data_conditional"),
         Input("selected-run-store", "data"),
         Input("window-comparison-metric-set", "value"),
         Input("window-dataset-filter", "value"),
@@ -459,17 +523,17 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
         selected_methods: list[Any] | None,
         selected_configs: list[Any] | None,
         selected_intervals: list[Any] | None,
-    ) -> tuple[Any, Any, Any, Any, Any, Any, Any, Any]:
+    ) -> tuple[Any, Any, Any, Any, Any, Any, Any, Any, Any]:
         if not run_payload:
             message = empty_state("Select a run to inspect window summaries.")
-            return [], [], [], [], message, message, [], []
+            return [], [], [], [], message, message, [], [], []
 
         rows = run_payload["window_rows"]
         if not rows:
             message = empty_state(
                 "This run has no populated window summary rows. Detailed views and graphs are planned next."
             )
-            return [], [], [], [], message, message, [], []
+            return [], [], [], [], message, message, [], [], []
 
         filtered_rows = _filter_rows(
             rows,
@@ -480,7 +544,7 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
                 "interval_seconds": selected_intervals or [],
             },
         )
-        comparison_columns, comparison_rows = _build_window_method_comparison(
+        comparison_columns, comparison_rows, comparison_styles = _build_window_method_comparison(
             filtered_rows, comparison_metric_set
         )
 
@@ -506,6 +570,7 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
             comparison_message,
             comparison_columns,
             comparison_rows,
+            comparison_styles,
         )
 
     @callback(

--- a/python/viewer/app.py
+++ b/python/viewer/app.py
@@ -6,7 +6,8 @@ import argparse
 from pathlib import Path
 from typing import Any
 
-from dash import Dash, Input, Output, callback, html
+import pandas as pd
+from dash import Dash, Input, Output, State, callback, html
 
 from .discovery import discover_runs
 from .layout import build_shell, empty_state, metadata_card, status_badge
@@ -35,23 +36,27 @@ def _format_cli_args(cli_args: str) -> str:
     return cli_args[:117] + "..."
 
 
+def _serialize_entry(entry: RunCatalogEntry) -> dict[str, Any]:
+    return {
+        "app_name": entry.app_name,
+        "run_id": entry.run_id,
+        "path": str(entry.path),
+        "status": entry.status,
+        "timestamp_utc": entry.timestamp_utc,
+        "cli_args": entry.cli_args,
+        "output_root": entry.output_root,
+        "repo_version": entry.repo_version,
+        "dataset_count": entry.dataset_count,
+        "dataset_group_label": entry.dataset_group_label,
+        "has_window_summaries": entry.has_window_summaries,
+        "has_calibration_summaries": entry.has_calibration_summaries,
+    }
+
+
 def _serialize_run_data(run_data: RunData) -> dict[str, Any]:
     entry = run_data.entry
     return {
-        "entry": {
-            "app_name": entry.app_name,
-            "run_id": entry.run_id,
-            "path": str(entry.path),
-            "status": entry.status,
-            "timestamp_utc": entry.timestamp_utc,
-            "cli_args": entry.cli_args,
-            "output_root": entry.output_root,
-            "repo_version": entry.repo_version,
-            "dataset_count": entry.dataset_count,
-            "dataset_group_label": entry.dataset_group_label,
-            "has_window_summaries": entry.has_window_summaries,
-            "has_calibration_summaries": entry.has_calibration_summaries,
-        },
+        "entry": _serialize_entry(entry),
         "metadata_columns": list(run_data.metadata.columns),
         "metadata_rows": run_data.metadata.to_dict("records"),
         "datasets_columns": list(run_data.datasets.columns),
@@ -80,6 +85,16 @@ def _deserialize_entry(payload: dict[str, Any]) -> RunCatalogEntry:
     )
 
 
+def _serialize_catalog(entries: list[RunCatalogEntry]) -> list[dict[str, Any]]:
+    return [_serialize_entry(entry) for entry in entries]
+
+
+def _deserialize_catalog(payload: list[dict[str, Any]] | None) -> list[RunCatalogEntry]:
+    if not payload:
+        return []
+    return [_deserialize_entry(entry_payload) for entry_payload in payload]
+
+
 def _table_columns(columns: list[str]) -> list[dict[str, str]]:
     return [{"name": column, "id": column} for column in columns]
 
@@ -98,25 +113,263 @@ def _dropdown_options(rows: list[dict[str, Any]], field: str) -> list[dict[str, 
     return [{"label": str(value), "value": value} for value in values]
 
 
+WINDOW_COMPARISON_METRIC_GROUPS = {
+    "core": [
+        "normalized_nees_mean",
+        "normalized_nees_median",
+        "rot_error_median",
+        "pos_error_median",
+        "vel_error_median",
+    ],
+    "nees": [
+        "normalized_nees_mean",
+        "normalized_nees_median",
+        "normalized_nees_p95",
+        "normalized_nees_variance",
+    ],
+    "errors": [
+        "rot_error_median",
+        "pos_error_median",
+        "vel_error_median",
+    ],
+    "sigmas": [
+        "rot_pred_sigma_median",
+        "pos_pred_sigma_median",
+        "vel_pred_sigma_median",
+    ],
+    "all": [
+        "normalized_nees_mean",
+        "normalized_nees_median",
+        "normalized_nees_p95",
+        "normalized_nees_variance",
+        "rot_error_median",
+        "rot_pred_sigma_median",
+        "pos_error_median",
+        "pos_pred_sigma_median",
+        "vel_error_median",
+        "vel_pred_sigma_median",
+    ],
+}
+
+WINDOW_METRIC_LABELS = {
+    "normalized_nees_mean": "Normalized NEES Mean",
+    "normalized_nees_median": "Normalized NEES Median",
+    "normalized_nees_p95": "Normalized NEES P95",
+    "normalized_nees_variance": "Normalized NEES Variance",
+    "rot_error_median": "Rotation Error Median",
+    "rot_pred_sigma_median": "Rotation Sigma Median",
+    "pos_error_median": "Position Error Median",
+    "pos_pred_sigma_median": "Position Sigma Median",
+    "vel_error_median": "Velocity Error Median",
+    "vel_pred_sigma_median": "Velocity Sigma Median",
+}
+
+WINDOW_COMPARISON_INDEX_COLUMNS = [
+    ("dataset", "Dataset"),
+    ("interval_seconds", "Interval Seconds"),
+    ("config_label", "Config Label"),
+    ("samples_per_window", "Samples / Window"),
+    ("sample_count", "Sample Count"),
+]
+
+
+def _method_sort_key(method: str) -> tuple[int, str]:
+    preferred_order = {
+        "quadrature": 0,
+        "manifold": 1,
+        "tangent": 2,
+        "gal3_imu_ekf": 3,
+        "navstate_imu_ekf": 4,
+    }
+    return preferred_order.get(method, 99), method
+
+
+def _pretty_method_name(method: str) -> str:
+    return method.replace("_", " ").title()
+
+
+def _build_window_method_comparison(
+    rows: list[dict[str, Any]], metric_group: str
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not rows:
+        return [], []
+
+    frame = pd.DataFrame(rows)
+    if frame.empty or "method" not in frame.columns:
+        return [], []
+
+    metrics = [
+        metric
+        for metric in WINDOW_COMPARISON_METRIC_GROUPS.get(metric_group, WINDOW_COMPARISON_METRIC_GROUPS["core"])
+        if metric in frame.columns
+    ]
+    if not metrics:
+        return [], []
+
+    index_columns = [column for column, _label in WINDOW_COMPARISON_INDEX_COLUMNS if column in frame.columns]
+    if not index_columns:
+        return [], []
+
+    method_names = sorted(frame["method"].dropna().unique().tolist(), key=_method_sort_key)
+    if not method_names:
+        return [], []
+
+    grouped = frame[index_columns + ["method", *metrics]].copy()
+    pivot = grouped.pivot_table(index=index_columns, columns="method", values=metrics, aggfunc="first")
+    if pivot.empty:
+        return [], []
+
+    columns: list[dict[str, Any]] = []
+    for column, label in WINDOW_COMPARISON_INDEX_COLUMNS:
+        if column in index_columns:
+            columns.append({"name": [label, ""], "id": column})
+
+    for metric in metrics:
+        metric_label = WINDOW_METRIC_LABELS.get(metric, metric)
+        for method_name in method_names:
+            column_id = f"{metric}__{method_name}"
+            columns.append(
+                {
+                    "name": [metric_label, _pretty_method_name(method_name)],
+                    "id": column_id,
+                    "type": "numeric",
+                }
+            )
+
+    comparison_rows: list[dict[str, Any]] = []
+    for index_values, series in pivot.iterrows():
+        if not isinstance(index_values, tuple):
+            index_values = (index_values,)
+        row: dict[str, Any] = {
+            index_columns[index]: index_values[index] for index in range(len(index_columns))
+        }
+        for metric in metrics:
+            for method_name in method_names:
+                row[f"{metric}__{method_name}"] = series.get((metric, method_name))
+        comparison_rows.append(row)
+
+    return columns, comparison_rows
+
+
+def _resolve_compare_paths(selected_path: str | None, compare_paths: list[str] | None) -> list[str]:
+    resolved: list[str] = []
+    for path in [selected_path, *(compare_paths or [])]:
+        if path and path not in resolved:
+            resolved.append(path)
+    return resolved
+
+
+def _load_payload_for_entry(entry: RunCatalogEntry) -> dict[str, Any]:
+    return _serialize_run_data(load_run_data(entry))
+
+
+def _load_compare_payloads(
+    catalog_payload: list[dict[str, Any]] | None,
+    selected_path: str | None,
+    compare_paths: list[str] | None,
+) -> list[dict[str, Any]]:
+    catalog = _deserialize_catalog(catalog_payload)
+    catalog_by_path = {str(entry.path): entry for entry in catalog}
+    payloads: list[dict[str, Any]] = []
+    for path in _resolve_compare_paths(selected_path, compare_paths):
+        entry = catalog_by_path.get(path)
+        if entry is None:
+            continue
+        payloads.append(_load_payload_for_entry(entry))
+    return payloads
+
+
+def _comparison_rows(run_payloads: list[dict[str, Any]], row_key: str) -> tuple[list[str], list[dict[str, Any]]]:
+    if not run_payloads:
+        return [], []
+
+    base_columns: list[str] = []
+    combined_rows: list[dict[str, Any]] = []
+    comparison_fields = {"run_label", "app_name", "run_id", "timestamp_utc", "status"}
+    for payload in run_payloads:
+        entry = _deserialize_entry(payload["entry"])
+        rows = payload[row_key]
+        if rows and not base_columns:
+            base_columns = [column for column in rows[0].keys() if column not in comparison_fields]
+        for row in rows:
+            payload_row = {key: value for key, value in row.items() if key not in comparison_fields}
+            combined_rows.append(
+                {
+                    "run_label": f"{entry.app_name} | {entry.run_id}",
+                    "app_name": entry.app_name,
+                    "run_id": entry.run_id,
+                    "timestamp_utc": entry.timestamp_utc,
+                    "status": entry.status,
+                    **payload_row,
+                }
+            )
+
+    columns = ["run_label", "app_name", "run_id", "timestamp_utc", "status", *base_columns]
+    return columns, combined_rows
+
+
 def create_dash_app(results_root: str | Path = "build/results") -> Dash:
     results_root_path = Path(results_root)
     catalog = discover_runs(results_root_path)
-    catalog_by_path = {str(entry.path): entry for entry in catalog}
 
     app = Dash(__name__, title="imuFactors Summary Viewer")
     app.layout = build_shell(catalog, results_root_path)
 
     @callback(
+        Output("catalog-store", "data"),
+        Output("run-select", "options"),
+        Output("run-select", "value"),
+        Output("compare-select", "options"),
+        Output("compare-select", "value"),
+        Output("run-list-note", "children"),
+        Input("refresh-runs-button", "n_clicks"),
+        State("run-select", "value"),
+        State("compare-select", "value"),
+    )
+    def refresh_catalog(
+        _refresh_clicks: int,
+        current_run: str | None,
+        current_compare: list[str] | None,
+    ) -> tuple[Any, Any, Any, Any, Any, Any]:
+        refreshed_catalog = discover_runs(results_root_path)
+        options = [
+            {
+                "label": f"{entry.app_name} | {entry.run_id} | "
+                f"{entry.dataset_group_label or (f'{entry.dataset_count} datasets' if entry.dataset_count else 'No dataset info')} | "
+                f"{entry.timestamp_utc or 'Unknown timestamp'}",
+                "value": str(entry.path),
+            }
+            for entry in refreshed_catalog
+        ]
+        values = {option["value"] for option in options}
+        selected_value = current_run if current_run in values else (options[0]["value"] if options else None)
+        compare_values = [path for path in (current_compare or []) if path in values]
+        if selected_value and selected_value not in compare_values:
+            compare_values = [selected_value, *compare_values]
+        note = f"{len(refreshed_catalog)} runs discovered"
+        return (
+            _serialize_catalog(refreshed_catalog),
+            options,
+            selected_value,
+            options,
+            compare_values,
+            note,
+        )
+
+    @callback(
         Output("selected-run-store", "data"),
+        Input("catalog-store", "data"),
         Input("run-select", "value"),
     )
-    def load_selected_run(run_path: str | None) -> dict[str, Any]:
-        if not run_path:
+    def load_selected_run(catalog_payload: list[dict[str, Any]] | None, run_path: str | None) -> dict[str, Any]:
+        if not catalog_payload or not run_path:
             return {}
+        catalog = _deserialize_catalog(catalog_payload)
+        catalog_by_path = {str(entry.path): entry for entry in catalog}
         entry = catalog_by_path.get(run_path)
         if entry is None:
             return {}
-        return _serialize_run_data(load_run_data(entry))
+        return _load_payload_for_entry(entry)
 
     @callback(
         Output("run-header", "children"),
@@ -189,17 +442,56 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
         Output("window-config-filter", "options"),
         Output("window-interval-filter", "options"),
         Output("window-summary-message", "children"),
+        Output("window-comparison-message", "children"),
+        Output("window-method-compare-table", "columns"),
+        Output("window-method-compare-table", "data"),
         Input("selected-run-store", "data"),
+        Input("window-comparison-metric-set", "value"),
+        Input("window-dataset-filter", "value"),
+        Input("window-method-filter", "value"),
+        Input("window-config-filter", "value"),
+        Input("window-interval-filter", "value"),
     )
-    def populate_window_filters(run_payload: dict[str, Any]) -> tuple[Any, Any, Any, Any, Any]:
+    def populate_window_filters(
+        run_payload: dict[str, Any],
+        comparison_metric_set: str,
+        selected_datasets: list[Any] | None,
+        selected_methods: list[Any] | None,
+        selected_configs: list[Any] | None,
+        selected_intervals: list[Any] | None,
+    ) -> tuple[Any, Any, Any, Any, Any, Any, Any, Any]:
         if not run_payload:
             message = empty_state("Select a run to inspect window summaries.")
-            return [], [], [], [], message
+            return [], [], [], [], message, message, [], []
 
         rows = run_payload["window_rows"]
         if not rows:
-            return [], [], [], [], empty_state(
+            message = empty_state(
                 "This run has no populated window summary rows. Detailed views and graphs are planned next."
+            )
+            return [], [], [], [], message, message, [], []
+
+        filtered_rows = _filter_rows(
+            rows,
+            {
+                "dataset": selected_datasets or [],
+                "method": selected_methods or [],
+                "config_label": selected_configs or [],
+                "interval_seconds": selected_intervals or [],
+            },
+        )
+        comparison_columns, comparison_rows = _build_window_method_comparison(
+            filtered_rows, comparison_metric_set
+        )
+
+        if comparison_rows:
+            comparison_message: Any = html.Div(
+                "Methods are pivoted side-by-side for the current dataset and interval filters.",
+                style={"color": "#7a6956", "fontSize": "13px"},
+            )
+        else:
+            comparison_message = empty_state(
+                "No comparable method rows remain for the current filters and metric set."
             )
 
         return (
@@ -211,6 +503,9 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
                 "Summary tables are live. TODO breadcrumbs for window detail tables and Plotly trend panels remain in the code.",
                 style={"color": "#7a6956", "fontSize": "13px"},
             ),
+            comparison_message,
+            comparison_columns,
+            comparison_rows,
         )
 
     @callback(
@@ -256,14 +551,14 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
         rows = run_payload["calibration_rows"]
         if not rows:
             return [], [], empty_state(
-                "This run has no populated calibration summary rows. Multi-run calibration compare is deferred to a later version."
+                "This run has no populated calibration summary rows. Comparison is still available when other selected runs contain calibration summaries."
             )
 
         return (
             _dropdown_options(rows, "study_name"),
             _dropdown_options(rows, "result_label"),
             html.Div(
-                "Calibration summaries are shown read-only in v1.",
+                "Calibration summaries are shown read-only.",
                 style={"color": "#7a6956", "fontSize": "13px"},
             ),
         )
@@ -289,7 +584,86 @@ def create_dash_app(results_root: str | Path = "build/results") -> Dash:
         )
         return _table_columns(run_payload["calibration_columns"]), rows
 
-    # TODO: Add multi-run comparison state once the MVP grows beyond a single selected run.
+    @callback(
+        Output("compare-summary-message", "children"),
+        Output("compare-window-dataset-filter", "options"),
+        Output("compare-window-method-filter", "options"),
+        Output("compare-window-config-filter", "options"),
+        Output("compare-window-interval-filter", "options"),
+        Output("compare-calibration-study-filter", "options"),
+        Output("compare-calibration-result-filter", "options"),
+        Output("compare-window-table", "columns"),
+        Output("compare-window-table", "data"),
+        Output("compare-calibration-table", "columns"),
+        Output("compare-calibration-table", "data"),
+        Input("catalog-store", "data"),
+        Input("run-select", "value"),
+        Input("compare-select", "value"),
+        Input("compare-window-dataset-filter", "value"),
+        Input("compare-window-method-filter", "value"),
+        Input("compare-window-config-filter", "value"),
+        Input("compare-window-interval-filter", "value"),
+        Input("compare-calibration-study-filter", "value"),
+        Input("compare-calibration-result-filter", "value"),
+    )
+    def render_comparisons(
+        catalog_payload: list[dict[str, Any]] | None,
+        selected_path: str | None,
+        compare_paths: list[str] | None,
+        compare_window_datasets: list[Any] | None,
+        compare_window_methods: list[Any] | None,
+        compare_window_configs: list[Any] | None,
+        compare_window_intervals: list[Any] | None,
+        compare_study_names: list[Any] | None,
+        compare_result_labels: list[Any] | None,
+    ) -> tuple[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]:
+        payloads = _load_compare_payloads(catalog_payload, selected_path, compare_paths)
+        if not payloads:
+            message = empty_state("Select an active run to compare summaries.")
+            return message, [], [], [], [], [], [], [], [], [], []
+
+        window_columns, window_rows = _comparison_rows(payloads, "window_rows")
+        calibration_columns, calibration_rows = _comparison_rows(payloads, "calibration_rows")
+
+        filtered_window_rows = _filter_rows(
+            window_rows,
+            {
+                "dataset": compare_window_datasets or [],
+                "method": compare_window_methods or [],
+                "config_label": compare_window_configs or [],
+                "interval_seconds": compare_window_intervals or [],
+            },
+        )
+        filtered_calibration_rows = _filter_rows(
+            calibration_rows,
+            {"study_name": compare_study_names or [], "result_label": compare_result_labels or []},
+        )
+
+        compared_run_count = len(payloads)
+        compared_label = "run" if compared_run_count == 1 else "runs"
+        if not window_rows and not calibration_rows:
+            message = empty_state("The selected runs do not contain populated summary rows to compare.")
+        else:
+            message = html.Div(
+                f"Comparing {compared_run_count} {compared_label}. "
+                "Window and calibration summaries are merged into shared comparison tables.",
+                style={"color": "#7a6956", "fontSize": "13px"},
+            )
+
+        return (
+            message,
+            _dropdown_options(window_rows, "dataset"),
+            _dropdown_options(window_rows, "method"),
+            _dropdown_options(window_rows, "config_label"),
+            _dropdown_options(window_rows, "interval_seconds"),
+            _dropdown_options(calibration_rows, "study_name"),
+            _dropdown_options(calibration_rows, "result_label"),
+            _table_columns(window_columns),
+            filtered_window_rows,
+            _table_columns(calibration_columns),
+            filtered_calibration_rows,
+        )
+
     # TODO: Add Plotly chart callbacks after detail tables and trajectory summaries are exposed.
     # TODO: Add window_metrics.csv and trajectory_samples.csv panels with explicit sampling controls.
     return app

--- a/python/viewer/app.py
+++ b/python/viewer/app.py
@@ -1,0 +1,305 @@
+"""Dash application entrypoint for summary-table viewing."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from dash import Dash, Input, Output, callback, html
+
+from .discovery import discover_runs
+from .layout import build_shell, empty_state, metadata_card, status_badge
+from .loading import load_run_data
+from .models import RunCatalogEntry, RunData
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dash summary viewer for imuFactors result packages.")
+    parser.add_argument(
+        "--results-root",
+        default="build/results",
+        help="Root directory containing canonical result packages (default: build/results).",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface for the Dash server.")
+    parser.add_argument("--port", type=int, default=8050, help="Port for the Dash server.")
+    parser.add_argument("--debug", action="store_true", help="Run Dash in debug mode.")
+    return parser.parse_args()
+
+
+def _format_cli_args(cli_args: str) -> str:
+    if not cli_args:
+        return "—"
+    if len(cli_args) <= 120:
+        return cli_args
+    return cli_args[:117] + "..."
+
+
+def _serialize_run_data(run_data: RunData) -> dict[str, Any]:
+    entry = run_data.entry
+    return {
+        "entry": {
+            "app_name": entry.app_name,
+            "run_id": entry.run_id,
+            "path": str(entry.path),
+            "status": entry.status,
+            "timestamp_utc": entry.timestamp_utc,
+            "cli_args": entry.cli_args,
+            "output_root": entry.output_root,
+            "repo_version": entry.repo_version,
+            "dataset_count": entry.dataset_count,
+            "dataset_group_label": entry.dataset_group_label,
+            "has_window_summaries": entry.has_window_summaries,
+            "has_calibration_summaries": entry.has_calibration_summaries,
+        },
+        "metadata_columns": list(run_data.metadata.columns),
+        "metadata_rows": run_data.metadata.to_dict("records"),
+        "datasets_columns": list(run_data.datasets.columns),
+        "datasets_rows": run_data.datasets.to_dict("records"),
+        "window_columns": list(run_data.window_summaries.columns),
+        "window_rows": run_data.window_summaries.to_dict("records"),
+        "calibration_columns": list(run_data.calibration_summaries.columns),
+        "calibration_rows": run_data.calibration_summaries.to_dict("records"),
+    }
+
+
+def _deserialize_entry(payload: dict[str, Any]) -> RunCatalogEntry:
+    return RunCatalogEntry(
+        app_name=payload["app_name"],
+        run_id=payload["run_id"],
+        path=Path(payload["path"]),
+        status=payload["status"],
+        timestamp_utc=payload.get("timestamp_utc", ""),
+        cli_args=payload.get("cli_args", ""),
+        output_root=payload.get("output_root", ""),
+        repo_version=payload.get("repo_version", ""),
+        dataset_count=payload.get("dataset_count", 0),
+        dataset_group_label=payload.get("dataset_group_label", ""),
+        has_window_summaries=payload.get("has_window_summaries", False),
+        has_calibration_summaries=payload.get("has_calibration_summaries", False),
+    )
+
+
+def _table_columns(columns: list[str]) -> list[dict[str, str]]:
+    return [{"name": column, "id": column} for column in columns]
+
+
+def _filter_rows(rows: list[dict[str, Any]], filters: dict[str, list[Any]]) -> list[dict[str, Any]]:
+    filtered = rows
+    for field, allowed_values in filters.items():
+        if not allowed_values:
+            continue
+        filtered = [row for row in filtered if row.get(field) in allowed_values]
+    return filtered
+
+
+def _dropdown_options(rows: list[dict[str, Any]], field: str) -> list[dict[str, Any]]:
+    values = sorted({row.get(field) for row in rows if row.get(field) not in ("", None)})
+    return [{"label": str(value), "value": value} for value in values]
+
+
+def create_dash_app(results_root: str | Path = "build/results") -> Dash:
+    results_root_path = Path(results_root)
+    catalog = discover_runs(results_root_path)
+    catalog_by_path = {str(entry.path): entry for entry in catalog}
+
+    app = Dash(__name__, title="imuFactors Summary Viewer")
+    app.layout = build_shell(catalog, results_root_path)
+
+    @callback(
+        Output("selected-run-store", "data"),
+        Input("run-select", "value"),
+    )
+    def load_selected_run(run_path: str | None) -> dict[str, Any]:
+        if not run_path:
+            return {}
+        entry = catalog_by_path.get(run_path)
+        if entry is None:
+            return {}
+        return _serialize_run_data(load_run_data(entry))
+
+    @callback(
+        Output("run-header", "children"),
+        Output("metadata-grid", "children"),
+        Output("datasets-table", "columns"),
+        Output("datasets-table", "data"),
+        Input("selected-run-store", "data"),
+    )
+    def render_overview(run_payload: dict[str, Any]) -> tuple[Any, Any, Any, Any]:
+        if not run_payload:
+            message = empty_state("No run selected. Point the app at a results root with canonical CSV packages.")
+            return message, [], [], []
+
+        entry = _deserialize_entry(run_payload["entry"])
+        dataset_label = entry.dataset_group_label or (
+            f"{entry.dataset_count} datasets" if entry.dataset_count else "No dataset info"
+        )
+        header = html.Div(
+            [
+                html.Div(
+                    [
+                        html.H2(entry.app_name, style={"margin": 0, "fontSize": "30px", "color": "#2d241b"}),
+                        html.Div(
+                            [
+                                status_badge(entry.status),
+                                html.Span(
+                                    dataset_label,
+                                    style={"marginLeft": "12px", "color": "#7a6956", "fontSize": "14px"},
+                                ),
+                            ],
+                            style={"marginTop": "10px"},
+                        ),
+                    ]
+                ),
+                html.P(
+                    _format_cli_args(entry.cli_args),
+                    style={
+                        "marginTop": "18px",
+                        "marginBottom": "0",
+                        "padding": "12px 14px",
+                        "backgroundColor": "#f8f4ed",
+                        "border": "1px solid #d8cfbf",
+                        "borderRadius": "14px",
+                        "color": "#5f4f3e",
+                        "fontFamily": "Menlo, Monaco, Consolas, monospace",
+                        "fontSize": "12px",
+                    },
+                ),
+            ],
+            style={"marginBottom": "24px"},
+        )
+
+        metadata_grid = [
+            metadata_card("Run ID", entry.run_id),
+            metadata_card("Timestamp", entry.timestamp_utc or "Unknown"),
+            metadata_card("Output Root", entry.output_root or str(entry.path.parent.parent)),
+            metadata_card("Repo Version", entry.repo_version or "Unknown"),
+        ]
+
+        return (
+            header,
+            metadata_grid,
+            _table_columns(run_payload["datasets_columns"]),
+            run_payload["datasets_rows"],
+        )
+
+    @callback(
+        Output("window-dataset-filter", "options"),
+        Output("window-method-filter", "options"),
+        Output("window-config-filter", "options"),
+        Output("window-interval-filter", "options"),
+        Output("window-summary-message", "children"),
+        Input("selected-run-store", "data"),
+    )
+    def populate_window_filters(run_payload: dict[str, Any]) -> tuple[Any, Any, Any, Any, Any]:
+        if not run_payload:
+            message = empty_state("Select a run to inspect window summaries.")
+            return [], [], [], [], message
+
+        rows = run_payload["window_rows"]
+        if not rows:
+            return [], [], [], [], empty_state(
+                "This run has no populated window summary rows. Detailed views and graphs are planned next."
+            )
+
+        return (
+            _dropdown_options(rows, "dataset"),
+            _dropdown_options(rows, "method"),
+            _dropdown_options(rows, "config_label"),
+            _dropdown_options(rows, "interval_seconds"),
+            html.Div(
+                "Summary tables are live. TODO breadcrumbs for window detail tables and Plotly trend panels remain in the code.",
+                style={"color": "#7a6956", "fontSize": "13px"},
+            ),
+        )
+
+    @callback(
+        Output("window-summary-table", "columns"),
+        Output("window-summary-table", "data"),
+        Input("selected-run-store", "data"),
+        Input("window-dataset-filter", "value"),
+        Input("window-method-filter", "value"),
+        Input("window-config-filter", "value"),
+        Input("window-interval-filter", "value"),
+    )
+    def render_window_summaries(
+        run_payload: dict[str, Any],
+        datasets: list[Any] | None,
+        methods: list[Any] | None,
+        config_labels: list[Any] | None,
+        intervals: list[Any] | None,
+    ) -> tuple[Any, Any]:
+        if not run_payload:
+            return [], []
+
+        rows = _filter_rows(
+            run_payload["window_rows"],
+            {
+                "dataset": datasets or [],
+                "method": methods or [],
+                "config_label": config_labels or [],
+                "interval_seconds": intervals or [],
+            },
+        )
+        return _table_columns(run_payload["window_columns"]), rows
+
+    @callback(
+        Output("calibration-study-filter", "options"),
+        Output("calibration-result-filter", "options"),
+        Output("calibration-summary-message", "children"),
+        Input("selected-run-store", "data"),
+    )
+    def populate_calibration_filters(run_payload: dict[str, Any]) -> tuple[Any, Any, Any]:
+        if not run_payload:
+            return [], [], empty_state("Select a run to inspect calibration summaries.")
+
+        rows = run_payload["calibration_rows"]
+        if not rows:
+            return [], [], empty_state(
+                "This run has no populated calibration summary rows. Multi-run calibration compare is deferred to a later version."
+            )
+
+        return (
+            _dropdown_options(rows, "study_name"),
+            _dropdown_options(rows, "result_label"),
+            html.Div(
+                "Calibration summaries are shown read-only in v1.",
+                style={"color": "#7a6956", "fontSize": "13px"},
+            ),
+        )
+
+    @callback(
+        Output("calibration-summary-table", "columns"),
+        Output("calibration-summary-table", "data"),
+        Input("selected-run-store", "data"),
+        Input("calibration-study-filter", "value"),
+        Input("calibration-result-filter", "value"),
+    )
+    def render_calibration_summaries(
+        run_payload: dict[str, Any],
+        study_names: list[Any] | None,
+        result_labels: list[Any] | None,
+    ) -> tuple[Any, Any]:
+        if not run_payload:
+            return [], []
+
+        rows = _filter_rows(
+            run_payload["calibration_rows"],
+            {"study_name": study_names or [], "result_label": result_labels or []},
+        )
+        return _table_columns(run_payload["calibration_columns"]), rows
+
+    # TODO: Add multi-run comparison state once the MVP grows beyond a single selected run.
+    # TODO: Add Plotly chart callbacks after detail tables and trajectory summaries are exposed.
+    # TODO: Add window_metrics.csv and trajectory_samples.csv panels with explicit sampling controls.
+    return app
+
+
+def main() -> None:
+    args = parse_args()
+    app = create_dash_app(args.results_root)
+    app.run(host=args.host, port=args.port, debug=args.debug)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/viewer/discovery.py
+++ b/python/viewer/discovery.py
@@ -1,0 +1,122 @@
+"""Run discovery and package status inspection for canonical result packages."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from .models import RunCatalogEntry
+
+CANONICAL_RESULT_FILES = (
+    "run_metadata.csv",
+    "datasets.csv",
+    "window_metrics.csv",
+    "window_summaries.csv",
+    "trajectory_samples.csv",
+    "calibration_trials.csv",
+    "calibration_summaries.csv",
+)
+
+SUMMARY_RESULT_FILES = ("window_summaries.csv", "calibration_summaries.csv")
+
+
+def _read_csv_rows(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    if not path.exists() or path.stat().st_size == 0:
+        return [], []
+
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            fieldnames = reader.fieldnames or []
+            rows = list(reader)
+    except (OSError, csv.Error):
+        return [], []
+
+    return fieldnames, rows
+
+
+def _csv_is_readable(path: Path) -> bool:
+    fieldnames, _ = _read_csv_rows(path)
+    return bool(fieldnames)
+
+
+def _csv_has_rows(path: Path) -> bool:
+    _, rows = _read_csv_rows(path)
+    return bool(rows)
+
+
+def _discover_dataset_info(run_dir: Path) -> tuple[int, str]:
+    fieldnames, rows = _read_csv_rows(run_dir / "datasets.csv")
+    if not fieldnames:
+        return 0, ""
+
+    dataset_groups = sorted(
+        {
+            row.get("dataset_group", "").strip()
+            for row in rows
+            if row.get("dataset_group", "").strip()
+        }
+    )
+    dataset_count = len(rows)
+    if len(dataset_groups) == 1:
+        return dataset_count, dataset_groups[0]
+    if dataset_count:
+        return dataset_count, f"{dataset_count} datasets"
+    return 0, ""
+
+
+def _metadata_fields(run_dir: Path) -> dict[str, str]:
+    fieldnames, rows = _read_csv_rows(run_dir / "run_metadata.csv")
+    if not fieldnames:
+        return {}
+    return rows[0] if rows else {}
+
+
+def _derive_status(run_dir: Path) -> str:
+    metadata_ok = _csv_is_readable(run_dir / "run_metadata.csv")
+    any_summary_ok = any(_csv_is_readable(run_dir / name) for name in SUMMARY_RESULT_FILES)
+    return "ready" if metadata_ok and any_summary_ok else "partial"
+
+
+def _make_catalog_entry(run_dir: Path) -> RunCatalogEntry:
+    metadata = _metadata_fields(run_dir)
+    dataset_count, dataset_group_label = _discover_dataset_info(run_dir)
+
+    return RunCatalogEntry(
+        app_name=metadata.get("app_name", run_dir.parent.name),
+        run_id=metadata.get("run_id", run_dir.name),
+        path=run_dir,
+        status=_derive_status(run_dir),
+        timestamp_utc=metadata.get("timestamp_utc", ""),
+        cli_args=metadata.get("cli_args", ""),
+        output_root=metadata.get("output_root", ""),
+        repo_version=metadata.get("repo_version", ""),
+        dataset_count=dataset_count,
+        dataset_group_label=dataset_group_label,
+        has_window_summaries=_csv_has_rows(run_dir / "window_summaries.csv"),
+        has_calibration_summaries=_csv_has_rows(run_dir / "calibration_summaries.csv"),
+    )
+
+
+def discover_runs(results_root: str | Path) -> list[RunCatalogEntry]:
+    """Discover canonical result-package directories under one results root."""
+
+    root = Path(results_root).expanduser()
+    if not root.exists():
+        return []
+
+    run_dirs: set[Path] = set()
+    for filename in CANONICAL_RESULT_FILES:
+        for file_path in root.rglob(filename):
+            run_dirs.add(file_path.parent)
+
+    catalog = [_make_catalog_entry(run_dir) for run_dir in run_dirs]
+    catalog.sort(
+        key=lambda entry: (
+            entry.timestamp_utc or entry.run_id,
+            entry.app_name,
+            entry.run_id,
+        ),
+        reverse=True,
+    )
+    return catalog

--- a/python/viewer/layout.py
+++ b/python/viewer/layout.py
@@ -1,0 +1,269 @@
+"""Dash layout helpers and styling for the summary viewer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dash import dash_table, dcc, html
+
+from .models import RunCatalogEntry
+
+APP_BACKGROUND = "#f4f1ea"
+PANEL_BACKGROUND = "#fcfaf6"
+PANEL_BORDER = "#d8cfbf"
+ACCENT = "#8f5d2b"
+TEXT = "#2d241b"
+MUTED = "#7a6956"
+
+
+def _status_colors(status: str) -> tuple[str, str]:
+    if status == "ready":
+        return "#e5f4e8", "#1f6b36"
+    return "#fff2d9", "#8a5a10"
+
+
+def format_run_option(entry: RunCatalogEntry) -> dict[str, str]:
+    dataset_label = entry.dataset_group_label or (
+        f"{entry.dataset_count} datasets" if entry.dataset_count else "No dataset info"
+    )
+    timestamp = entry.timestamp_utc or "Unknown timestamp"
+    label = f"{entry.app_name} | {entry.run_id} | {dataset_label} | {timestamp}"
+    return {"label": label, "value": str(entry.path)}
+
+
+def status_badge(status: str) -> html.Span:
+    background, foreground = _status_colors(status)
+    return html.Span(
+        status.upper(),
+        style={
+            "display": "inline-block",
+            "padding": "4px 10px",
+            "borderRadius": "999px",
+            "backgroundColor": background,
+            "color": foreground,
+            "fontSize": "12px",
+            "fontWeight": 700,
+            "letterSpacing": "0.08em",
+        },
+    )
+
+
+def empty_state(message: str) -> html.Div:
+    return html.Div(
+        message,
+        style={
+            "padding": "20px",
+            "border": f"1px dashed {PANEL_BORDER}",
+            "borderRadius": "14px",
+            "color": MUTED,
+            "backgroundColor": "#f8f4ed",
+        },
+    )
+
+
+def metadata_card(label: str, value: str) -> html.Div:
+    return html.Div(
+        [
+            html.Div(label, style={"fontSize": "12px", "color": MUTED, "textTransform": "uppercase"}),
+            html.Div(value or "—", style={"fontSize": "15px", "fontWeight": 600, "color": TEXT}),
+        ],
+        style={
+            "padding": "14px 16px",
+            "backgroundColor": PANEL_BACKGROUND,
+            "border": f"1px solid {PANEL_BORDER}",
+            "borderRadius": "14px",
+        },
+    )
+
+
+def build_filter_dropdown(component_id: str, label: str) -> html.Div:
+    return html.Div(
+        [
+            html.Label(label, htmlFor=component_id, style={"fontSize": "12px", "color": MUTED}),
+            dcc.Dropdown(id=component_id, multi=True, placeholder=f"Filter {label.lower()}"),
+        ],
+        style={"minWidth": "180px", "flex": "1 1 180px"},
+    )
+
+
+def build_data_table(table_id: str) -> dash_table.DataTable:
+    return dash_table.DataTable(
+        id=table_id,
+        page_size=12,
+        sort_action="native",
+        filter_action="native",
+        style_as_list_view=False,
+        style_table={"overflowX": "auto"},
+        style_header={
+            "backgroundColor": "#efe7db",
+            "border": f"1px solid {PANEL_BORDER}",
+            "fontWeight": 700,
+            "color": TEXT,
+        },
+        style_cell={
+            "textAlign": "left",
+            "padding": "10px 12px",
+            "border": f"1px solid {PANEL_BORDER}",
+            "backgroundColor": PANEL_BACKGROUND,
+            "color": TEXT,
+            "fontFamily": "Menlo, Monaco, Consolas, monospace",
+            "fontSize": "12px",
+            "maxWidth": 320,
+            "whiteSpace": "normal",
+        },
+    )
+
+
+def build_shell(catalog: list[RunCatalogEntry], results_root: Path) -> html.Div:
+    options = [format_run_option(entry) for entry in catalog]
+    default_value = options[0]["value"] if options else None
+
+    return html.Div(
+        [
+            dcc.Store(id="selected-run-store"),
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.H1(
+                                "imuFactors Summary Viewer",
+                                style={"margin": "0 0 6px 0", "fontSize": "28px", "color": TEXT},
+                            ),
+                            html.P(
+                                "CSV-backed Dash MVP for canonical result packages.",
+                                style={"margin": 0, "color": MUTED},
+                            ),
+                        ],
+                        style={"marginBottom": "24px"},
+                    ),
+                    html.Div(
+                        [
+                            html.Div("Results Root", style={"fontSize": "12px", "color": MUTED}),
+                            html.Code(str(results_root), style={"color": TEXT, "fontSize": "13px"}),
+                        ],
+                        style={
+                            "padding": "14px 16px",
+                            "borderRadius": "14px",
+                            "backgroundColor": PANEL_BACKGROUND,
+                            "border": f"1px solid {PANEL_BORDER}",
+                            "marginBottom": "18px",
+                        },
+                    ),
+                    html.Label("Run", htmlFor="run-select", style={"fontSize": "12px", "color": MUTED}),
+                    dcc.Dropdown(
+                        id="run-select",
+                        options=options,
+                        value=default_value,
+                        placeholder="Select a discovered run",
+                        clearable=False,
+                    ),
+                    html.Div(
+                        id="run-list-note",
+                        children=f"{len(catalog)} runs discovered",
+                        style={"marginTop": "14px", "fontSize": "13px", "color": MUTED},
+                    ),
+                    html.Div(
+                        [
+                            html.Div("Planned next:", style={"fontSize": "12px", "color": MUTED}),
+                            html.Ul(
+                                [
+                                    html.Li("Multi-run summary compare"),
+                                    html.Li("Window detail tables"),
+                                    html.Li("Trajectory views and graphs"),
+                                ],
+                                style={"paddingLeft": "20px", "margin": "10px 0 0 0", "color": TEXT},
+                            ),
+                        ],
+                        style={"marginTop": "24px"},
+                    ),
+                ],
+                style={
+                    "width": "320px",
+                    "padding": "28px",
+                    "borderRight": f"1px solid {PANEL_BORDER}",
+                    "background": "linear-gradient(180deg, #f7f1e7 0%, #f2ebdf 100%)",
+                },
+            ),
+            html.Div(
+                [
+                    html.Div(id="run-header"),
+                    dcc.Tabs(
+                        id="summary-tabs",
+                        value="overview",
+                        children=[
+                            dcc.Tab(
+                                label="Overview",
+                                value="overview",
+                                children=[
+                                    html.Div(
+                                        id="metadata-grid",
+                                        style={
+                                            "display": "grid",
+                                            "gap": "12px",
+                                            "gridTemplateColumns": "repeat(auto-fit, minmax(220px, 1fr))",
+                                        },
+                                    ),
+                                    html.Div(
+                                        [
+                                            html.H3("Datasets", style={"color": TEXT}),
+                                            build_data_table("datasets-table"),
+                                        ],
+                                        style={"marginTop": "24px"},
+                                    ),
+                                ],
+                            ),
+                            dcc.Tab(
+                                label="Window Summaries",
+                                value="window-summaries",
+                                children=[
+                                    html.Div(
+                                        [
+                                            build_filter_dropdown("window-dataset-filter", "Dataset"),
+                                            build_filter_dropdown("window-method-filter", "Method"),
+                                            build_filter_dropdown("window-config-filter", "Config Label"),
+                                            build_filter_dropdown("window-interval-filter", "Interval Seconds"),
+                                        ],
+                                        style={
+                                            "display": "flex",
+                                            "gap": "12px",
+                                            "flexWrap": "wrap",
+                                            "margin": "18px 0",
+                                        },
+                                    ),
+                                    html.Div(id="window-summary-message", style={"marginBottom": "12px"}),
+                                    build_data_table("window-summary-table"),
+                                ],
+                            ),
+                            dcc.Tab(
+                                label="Calibration Summaries",
+                                value="calibration-summaries",
+                                children=[
+                                    html.Div(
+                                        [
+                                            build_filter_dropdown("calibration-study-filter", "Study Name"),
+                                            build_filter_dropdown("calibration-result-filter", "Result Label"),
+                                        ],
+                                        style={
+                                            "display": "flex",
+                                            "gap": "12px",
+                                            "flexWrap": "wrap",
+                                            "margin": "18px 0",
+                                        },
+                                    ),
+                                    html.Div(id="calibration-summary-message", style={"marginBottom": "12px"}),
+                                    build_data_table("calibration-summary-table"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+                style={"flex": "1 1 auto", "padding": "28px", "overflow": "auto"},
+            ),
+        ],
+        style={
+            "display": "flex",
+            "minHeight": "100vh",
+            "background": f"radial-gradient(circle at top left, #fff7eb 0%, {APP_BACKGROUND} 55%)",
+            "fontFamily": "'Avenir Next', 'Segoe UI', sans-serif",
+        },
+    )

--- a/python/viewer/layout.py
+++ b/python/viewer/layout.py
@@ -86,12 +86,13 @@ def build_filter_dropdown(component_id: str, label: str) -> html.Div:
     )
 
 
-def build_data_table(table_id: str) -> dash_table.DataTable:
+def build_data_table(table_id: str, merge_duplicate_headers: bool = False) -> dash_table.DataTable:
     return dash_table.DataTable(
         id=table_id,
         page_size=12,
         sort_action="native",
         filter_action="native",
+        merge_duplicate_headers=merge_duplicate_headers,
         style_as_list_view=False,
         style_table={"overflowX": "auto"},
         style_header={
@@ -120,6 +121,7 @@ def build_shell(catalog: list[RunCatalogEntry], results_root: Path) -> html.Div:
 
     return html.Div(
         [
+            dcc.Store(id="catalog-store"),
             dcc.Store(id="selected-run-store"),
             html.Div(
                 [
@@ -130,7 +132,7 @@ def build_shell(catalog: list[RunCatalogEntry], results_root: Path) -> html.Div:
                                 style={"margin": "0 0 6px 0", "fontSize": "28px", "color": TEXT},
                             ),
                             html.P(
-                                "CSV-backed Dash MVP for canonical result packages.",
+                                "CSV-backed Dash viewer for canonical result packages.",
                                 style={"margin": 0, "color": MUTED},
                             ),
                         ],
@@ -157,22 +159,47 @@ def build_shell(catalog: list[RunCatalogEntry], results_root: Path) -> html.Div:
                         placeholder="Select a discovered run",
                         clearable=False,
                     ),
+                    html.Div(style={"height": "16px"}),
+                    html.Label("Compare Against", htmlFor="compare-select", style={"fontSize": "12px", "color": MUTED}),
+                    dcc.Dropdown(
+                        id="compare-select",
+                        options=options,
+                        value=[default_value] if default_value else [],
+                        placeholder="Select additional runs for comparison",
+                        multi=True,
+                    ),
+                    html.Button(
+                        "Refresh Runs",
+                        id="refresh-runs-button",
+                        n_clicks=0,
+                        style={
+                            "marginTop": "18px",
+                            "width": "100%",
+                            "padding": "12px 14px",
+                            "borderRadius": "12px",
+                            "border": f"1px solid {ACCENT}",
+                            "backgroundColor": ACCENT,
+                            "color": "#fff8ef",
+                            "fontWeight": 700,
+                            "cursor": "pointer",
+                        },
+                    ),
                     html.Div(
                         id="run-list-note",
                         children=f"{len(catalog)} runs discovered",
                         style={"marginTop": "14px", "fontSize": "13px", "color": MUTED},
                     ),
-                    html.Div(
-                        [
-                            html.Div("Planned next:", style={"fontSize": "12px", "color": MUTED}),
-                            html.Ul(
+                            html.Div(
                                 [
-                                    html.Li("Multi-run summary compare"),
-                                    html.Li("Window detail tables"),
-                                    html.Li("Trajectory views and graphs"),
-                                ],
-                                style={"paddingLeft": "20px", "margin": "10px 0 0 0", "color": TEXT},
-                            ),
+                                    html.Div("Planned next:", style={"fontSize": "12px", "color": MUTED}),
+                                    html.Ul(
+                                        [
+                                            html.Li("Window detail tables"),
+                                            html.Li("Trajectory views and graphs"),
+                                            html.Li("Plotly trend panels"),
+                                        ],
+                                        style={"paddingLeft": "20px", "margin": "10px 0 0 0", "color": TEXT},
+                                    ),
                         ],
                         style={"marginTop": "24px"},
                     ),
@@ -222,6 +249,28 @@ def build_shell(catalog: list[RunCatalogEntry], results_root: Path) -> html.Div:
                                             build_filter_dropdown("window-method-filter", "Method"),
                                             build_filter_dropdown("window-config-filter", "Config Label"),
                                             build_filter_dropdown("window-interval-filter", "Interval Seconds"),
+                                            html.Div(
+                                                [
+                                                    html.Label(
+                                                        "Comparison Metric Set",
+                                                        htmlFor="window-comparison-metric-set",
+                                                        style={"fontSize": "12px", "color": MUTED},
+                                                    ),
+                                                    dcc.Dropdown(
+                                                        id="window-comparison-metric-set",
+                                                        options=[
+                                                            {"label": "Core Metrics", "value": "core"},
+                                                            {"label": "NEES Statistics", "value": "nees"},
+                                                            {"label": "Error Medians", "value": "errors"},
+                                                            {"label": "Sigma Medians", "value": "sigmas"},
+                                                            {"label": "All Summary Metrics", "value": "all"},
+                                                        ],
+                                                        value="core",
+                                                        clearable=False,
+                                                    ),
+                                                ],
+                                                style={"minWidth": "220px", "flex": "1 1 220px"},
+                                            ),
                                         ],
                                         style={
                                             "display": "flex",
@@ -231,6 +280,13 @@ def build_shell(catalog: list[RunCatalogEntry], results_root: Path) -> html.Div:
                                         },
                                     ),
                                     html.Div(id="window-summary-message", style={"marginBottom": "12px"}),
+                                    html.H3("Method Comparison", style={"color": TEXT}),
+                                    html.Div(
+                                        id="window-comparison-message",
+                                        style={"marginBottom": "12px", "color": MUTED, "fontSize": "13px"},
+                                    ),
+                                    build_data_table("window-method-compare-table", merge_duplicate_headers=True),
+                                    html.H3("Raw Summary Rows", style={"color": TEXT, "marginTop": "28px"}),
                                     build_data_table("window-summary-table"),
                                 ],
                             ),
@@ -252,6 +308,47 @@ def build_shell(catalog: list[RunCatalogEntry], results_root: Path) -> html.Div:
                                     ),
                                     html.Div(id="calibration-summary-message", style={"marginBottom": "12px"}),
                                     build_data_table("calibration-summary-table"),
+                                ],
+                            ),
+                            dcc.Tab(
+                                label="Compare",
+                                value="compare",
+                                children=[
+                                    html.Div(
+                                        "Comparison includes the active run plus any additional selected runs from the sidebar.",
+                                        style={"margin": "18px 0", "color": MUTED, "fontSize": "13px"},
+                                    ),
+                                    html.Div(id="compare-summary-message", style={"marginBottom": "12px"}),
+                                    html.Div(
+                                        [
+                                            build_filter_dropdown("compare-window-dataset-filter", "Dataset"),
+                                            build_filter_dropdown("compare-window-method-filter", "Method"),
+                                            build_filter_dropdown("compare-window-config-filter", "Config Label"),
+                                            build_filter_dropdown("compare-window-interval-filter", "Interval Seconds"),
+                                        ],
+                                        style={
+                                            "display": "flex",
+                                            "gap": "12px",
+                                            "flexWrap": "wrap",
+                                            "margin": "18px 0",
+                                        },
+                                    ),
+                                    html.H3("Window Summary Comparison", style={"color": TEXT}),
+                                    build_data_table("compare-window-table"),
+                                    html.Div(
+                                        [
+                                            build_filter_dropdown("compare-calibration-study-filter", "Study Name"),
+                                            build_filter_dropdown("compare-calibration-result-filter", "Result Label"),
+                                        ],
+                                        style={
+                                            "display": "flex",
+                                            "gap": "12px",
+                                            "flexWrap": "wrap",
+                                            "margin": "28px 0 18px 0",
+                                        },
+                                    ),
+                                    html.H3("Calibration Summary Comparison", style={"color": TEXT}),
+                                    build_data_table("compare-calibration-table"),
                                 ],
                             ),
                         ],

--- a/python/viewer/loading.py
+++ b/python/viewer/loading.py
@@ -1,0 +1,33 @@
+"""Lazy CSV loading helpers for summary-table viewer state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from .models import RunCatalogEntry, RunData
+
+
+def load_csv_frame(path: Path) -> pd.DataFrame:
+    """Read one CSV into a DataFrame, normalizing empty states to an empty frame."""
+
+    if not path.exists() or path.stat().st_size == 0:
+        return pd.DataFrame()
+
+    try:
+        return pd.read_csv(path)
+    except (OSError, pd.errors.EmptyDataError, pd.errors.ParserError):
+        return pd.DataFrame()
+
+
+def load_run_data(entry: RunCatalogEntry) -> RunData:
+    """Load only the summary-facing CSVs for one selected run."""
+
+    return RunData(
+        entry=entry,
+        metadata=load_csv_frame(entry.path / "run_metadata.csv"),
+        datasets=load_csv_frame(entry.path / "datasets.csv"),
+        window_summaries=load_csv_frame(entry.path / "window_summaries.csv"),
+        calibration_summaries=load_csv_frame(entry.path / "calibration_summaries.csv"),
+    )

--- a/python/viewer/models.py
+++ b/python/viewer/models.py
@@ -1,0 +1,35 @@
+"""Data models for the Dash summary viewer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RunCatalogEntry:
+    """Catalog entry for one discovered result package."""
+
+    app_name: str
+    run_id: str
+    path: Path
+    status: str
+    timestamp_utc: str = ""
+    cli_args: str = ""
+    output_root: str = ""
+    repo_version: str = ""
+    dataset_count: int = 0
+    dataset_group_label: str = ""
+    has_window_summaries: bool = False
+    has_calibration_summaries: bool = False
+
+
+@dataclass(frozen=True)
+class RunData:
+    """Loaded summary data for one run."""
+
+    entry: RunCatalogEntry
+    metadata: "pd.DataFrame"
+    datasets: "pd.DataFrame"
+    window_summaries: "pd.DataFrame"
+    calibration_summaries: "pd.DataFrame"

--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -1,0 +1,5 @@
+"""Repo-root shim for `python -m viewer.app`."""
+
+from python.viewer import create_dash_app, main
+
+__all__ = ["create_dash_app", "main"]

--- a/viewer/app.py
+++ b/viewer/app.py
@@ -1,0 +1,7 @@
+"""Repo-root shim module for `python -m viewer.app`."""
+
+from python.viewer.app import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add a Python Dash viewer for canonical result packages and extend it with refreshable multi-run summary comparisons.

<img width="1494" height="885" alt="image" src="https://github.com/user-attachments/assets/04422d96-db26-4ea4-9165-ddb1948a7d46" />

## What changed
- add a Dash-based summary viewer that launches with `python -m viewer.app`
- discover canonical CSV run packages under one results root and classify runs as ready or partial
- show run metadata, dataset membership, window summaries, and calibration summaries for the active run
- add a refresh button to rescan runs without restarting Dash
- add multi-run comparison tables that merge summary rows across selected runs
- add a pivoted method-comparison table in Window Summaries so methods such as quadrature, manifold, and tangent appear side-by-side for the same dataset and interval
- document the viewer workflow and roadmap in `README.md`
- add Python smoke tests for discovery, loading, and summary comparison helpers

## Why
The canonical CSV export flow was already in place, but there was no usable app to inspect runs, compare methods, or compare multiple runs without digging through raw CSV files.

## Validation
- `python -m unittest discover -s python/tests -p 'test_*.py'`
- `make -j6 testResultsWriter.run`
- manual smoke checks against `build/ui_probe`

## Impact
This adds a lightweight analysis UI in Python without changing the C++ results schema or the existing evaluation binaries.
